### PR TITLE
Fix params for new workflow methods

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2476,7 +2476,7 @@ Create a workflow by a JSON configuration
 
 
 ```
-createConfigured(string <account-id>, int <schema-version>, string <workflow-configuration>): string
+createConfigured(string <name>, int <schema-version>, string <workflow-configuration>, int <category-id>): ResourceInformationInterface
 ```
 
 
@@ -2484,5 +2484,5 @@ Export a specific workflow configuration as JSON string
 
 
 ```
-export(string <workflow-id>): string
+export(int <workflow-id>): string
 ```

--- a/src/Client/Workflow/WorkflowClient.php
+++ b/src/Client/Workflow/WorkflowClient.php
@@ -105,34 +105,37 @@ final class WorkflowClient extends AbstractClient implements WorkflowClientInter
     /**
      * Create a workflow by a JSON configuration
      *
-     * @param string $accountId
+     * @param string $name
      * @param int $schemaVersion
      * @param string $workflowConfiguration
+     * @param int $categoryId
      *
-     * @return int
+     * @return ResourceInformationInterface
      * @throws EmptyResultException
      */
-    public function createConfigured(string $accountId, int $schemaVersion, string $workflowConfiguration): int
+    public function createConfigured(string $name, int $schemaVersion, string $workflowConfiguration, int $categoryId = 0): ResourceInformationInterface
     {
-        return $this->responseMapper->getInteger(
+        return $this->responseMapper->getObject(
             $this->soapClient->createConfigured([
-                'account_id' => $accountId,
+                'name' => $name,
                 'schema_version' => $schemaVersion,
-                'workflow_configuration' => $workflowConfiguration
+                'configuration' => $workflowConfiguration,
+                'category_id' => $categoryId
             ]),
-            'createConfiguredResult'
+            'createConfiguredResult',
+            $this->hydratorConfigFactory->createResourceInformationConfig()
         );
     }
 
     /**
      * Export a specific workflow configuration as JSON string
      *
-     * @param string $workflowId
+     * @param int $workflowId
      *
      * @return string
      * @throws EmptyResultException
      */
-    public function export(string $workflowId): string
+    public function export(int $workflowId): string
     {
         return $this->responseMapper->getString(
             $this->soapClient->export([

--- a/src/Client/Workflow/WorkflowClientInterface.php
+++ b/src/Client/Workflow/WorkflowClientInterface.php
@@ -53,21 +53,20 @@ interface WorkflowClientInterface extends ClientInterface, ResourceTraitInterfac
     public function pushProfilesIntoCampaign(int $id, array $profileIds): bool;
 
     /**
-     * @param string $accountId
+     * @param string $name
      * @param int $schemaVersion
      * @param string $workflowConfiguration
+     * @param int $categoryId
      *
-     * @return int
-     * @throws EmptyResultException
+     * @return ResourceInformationInterface
      */
-    public function createConfigured(string $accountId, int $schemaVersion, string $workflowConfiguration): int;
+    public function createConfigured(string $name, int $schemaVersion, string $workflowConfiguration, int $categoryId = 0): ResourceInformationInterface;
 
     /**
-     * @param string $workflowId
+     * @param int $workflowId
      *
      * @return string
      * @throws EmptyResultException
      */
-    public function export(string $workflowId): string;
-
+    public function export(int $workflowId): string;
 }

--- a/tests/Client/Workflow/WorkflowClientTest.php
+++ b/tests/Client/Workflow/WorkflowClientTest.php
@@ -166,7 +166,7 @@ class WorkflowClientTest extends TestCase
         $this->assertTrue($this->subject->pushProfilesIntoCampaign($id, $profileIds));
     }
 
-    public function testCreateConfiguredReturnsInt()
+    public function testCreateConfiguredReturnsResourceInformation()
     {
         $name = 123;
         $schemaVersion = 1;

--- a/tests/Client/Workflow/WorkflowClientTest.php
+++ b/tests/Client/Workflow/WorkflowClientTest.php
@@ -168,34 +168,43 @@ class WorkflowClientTest extends TestCase
 
     public function testCreateConfiguredReturnsInt()
     {
-        $accountId = 123;
+        $name = 123;
         $schemaVersion = 1;
         $workflowConfiguration = 'my config';
+        $categoryId = 456;
 
-        $result_int = 42;
+        $resourceInformation = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $result = new \stdClass();
-        $result->createResult = $result_int;
+        $result->createResult = $resourceInformation;
 
         $this->soapClient->expects($this->once())->method('createConfigured')->with([
-            'account_id' => $accountId,
+            'name' => $name,
             'schema_version' => $schemaVersion,
-            'workflow_configuration' => $workflowConfiguration,
+            'configuration' => $workflowConfiguration,
+            'category_id' => $categoryId,
         ])->willReturn($result);
+
+        $resourceInformationConfig = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
+        $this->hydratorConfigFactory
+            ->expects($this->once())
+            ->method('createResourceInformationConfig')
+            ->with()
+            ->willReturn($resourceInformationConfig);
 
         $this->responseMapper
             ->expects($this->once())
-            ->method('getInteger')
-            ->with($result, 'createConfiguredResult')
-            ->willReturn($result_int);
+            ->method('getObject')
+            ->with($result, 'createConfiguredResult', $resourceInformationConfig)
+            ->willReturn($resourceInformation);
         $this->assertSame(
-            $result_int,
-            $this->subject->createConfigured($accountId, $schemaVersion, $workflowConfiguration)
+            $resourceInformation,
+            $this->subject->createConfigured($name, $schemaVersion, $workflowConfiguration, $categoryId)
         );
     }
 
     public function testExportReturnString()
     {
-        $workflowId = 'my workflow';
+        $workflowId = 42;
 
         $result_string = 'my result';
         $result = new \stdClass();


### PR DESCRIPTION
Methods export and createConfigured have wrong params or type hints.
Fixes #42.