### PR TITLE
Correct hydractor config test namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "scn/hydrator-property-values": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8"
+    "php": ">=7.3",
+    "phpunit/phpunit": "^9"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,17 @@
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.3/phpunit.xsd"
-        backupGlobals="true"
-        backupStaticAttributes="false"
-        bootstrap="vendor/autoload.php"
-        cacheTokens="false"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        forceCoversAnnotation="false"
-        verbose="true">
-
-    <testsuites>
-        <testsuite name="Unittests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">./</directory>
-            <exclude>
-                <directory suffix=".php">vendor/</directory>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="true" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" forceCoversAnnotation="false" verbose="true">
+  <coverage includeUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">vendor/</directory>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unittests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Client/Mailing/MailingTemplateClient.php
+++ b/src/Client/Mailing/MailingTemplateClient.php
@@ -32,7 +32,7 @@ class MailingTemplateClient extends AbstractClient implements MailingTemplateCli
      * @param int $folderId
      *
      * @return ResourceInformationInterface
-     * @throws \Scn\EvalancheSoapApiConnector\Exception\EmptyResultException
+     * @throws EmptyResultException
      */
     public function create(
         string $title,
@@ -55,7 +55,7 @@ class MailingTemplateClient extends AbstractClient implements MailingTemplateCli
      * @param string $title
      *
      * @return ResourceInformationInterface
-     * @throws \Scn\EvalancheSoapApiConnector\Exception\EmptyResultException
+     * @throws EmptyResultException
      */
     public function updateTitle(int $id, string $title): ResourceInformationInterface
     {
@@ -309,7 +309,7 @@ class MailingTemplateClient extends AbstractClient implements MailingTemplateCli
      * @param int $id
      * 
      * @return MailingSlotConfigurationInterface
-     * @throws \Scn\EvalancheSoapApiConnector\Exception\EmptyResultException
+     * @throws EmptyResultException
      */
     public function getSlotConfiguration(int $id): MailingSlotConfigurationInterface
     {
@@ -327,7 +327,7 @@ class MailingTemplateClient extends AbstractClient implements MailingTemplateCli
      * @param int $slotNumber
      *
      * @return MailingSlotInterface
-     * @throws \Scn\EvalancheSoapApiConnector\Exception\EmptyResultException
+     * @throws EmptyResultException
      */
     public function addSlot(
         int $id,
@@ -354,7 +354,7 @@ class MailingTemplateClient extends AbstractClient implements MailingTemplateCli
      * @param int $sortValue
      *
      * @return MailingSlotInterface
-     * @throws \Scn\EvalancheSoapApiConnector\Exception\EmptyResultException
+     * @throws EmptyResultException
      */
     public function updateSlot(
         int $id,
@@ -387,7 +387,7 @@ class MailingTemplateClient extends AbstractClient implements MailingTemplateCli
      * @param int $articleTypeId
      *
      * @return MailingSlotItemInterface
-     * @throws \Scn\EvalancheSoapApiConnector\Exception\EmptyResultException
+     * @throws EmptyResultException
      */
     public function addTemplatesToSlot(
         int $id,
@@ -416,7 +416,7 @@ class MailingTemplateClient extends AbstractClient implements MailingTemplateCli
      * @param int $articleTypeId
      *
      * @return MailingSlotItemInterface
-     * @throws \Scn\EvalancheSoapApiConnector\Exception\EmptyResultException
+     * @throws EmptyResultException
      */
     public function updateSlotTemplates(
         int $id,

--- a/tests/Client/Account/AccountClientTest.php
+++ b/tests/Client/Account/AccountClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Account;
 
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Client/Article/ArticleClientTest.php
+++ b/tests/Client/Article/ArticleClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Article;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -11,6 +13,7 @@ use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
+use stdClass;
 
 /**
  * Class ArticleClientTest
@@ -77,7 +80,7 @@ class ArticleClientTest extends TestCase
             'some' => 'value'
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -114,7 +117,7 @@ class ArticleClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getDataResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createHashMapConfig')->willReturn($config);
@@ -139,7 +142,7 @@ class ArticleClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateResult = $object;
 
         $extractedData = [

--- a/tests/Client/Article/ArticleTemplateClientTest.php
+++ b/tests/Client/Article/ArticleTemplateClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Article;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -9,8 +11,8 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
-use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
+use stdClass;
 
 class ArticleTemplateClientTest extends TestCase
 {
@@ -70,7 +72,7 @@ class ArticleTemplateClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())
@@ -106,7 +108,7 @@ class ArticleTemplateClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())

--- a/tests/Client/Article/ArticleTypeClientTest.php
+++ b/tests/Client/Article/ArticleTypeClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Article;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,6 +15,7 @@ use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeGroupInterface;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeInterface;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeOptionInterface;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeRoleTypeInterface;
+use stdClass;
 
 /**
  * Class ArticleTypeClientTest
@@ -87,7 +90,7 @@ class ArticleTypeClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ContainerAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createContainerAttributeConfig')->willReturn($config);
@@ -118,7 +121,7 @@ class ArticleTypeClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ContainerAttributeGroupInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeGroupResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createContainerAttributeGroupConfig')->willReturn($config);
@@ -144,7 +147,7 @@ class ArticleTypeClientTest extends TestCase
         $attributeId = 456;
         $roleTypeId = 234;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->assignRoleToAttributeResult = true;
 
         $this->soapClient->expects($this->once())->method('assignRoleToAttribute')->with([
@@ -166,7 +169,7 @@ class ArticleTypeClientTest extends TestCase
         $attributeId = 23;
         $typeId = 234;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->changeAttributeTypeResult = true;
 
         $this->soapClient->expects($this->once())->method('changeAttributeType')->with([
@@ -191,7 +194,7 @@ class ArticleTypeClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createAttributeOptionResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createContainerAttributeOptionConfig')->willReturn($config);
@@ -221,7 +224,7 @@ class ArticleTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeRoleTypeInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeRoleTypeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getApplicableRoleTypeResults = [
             $object,
             $otherObject
@@ -252,7 +255,7 @@ class ArticleTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeRoleTypeInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeRoleTypeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAssignedRoleTypesResult = [
             $object,
             $otherObject
@@ -282,7 +285,7 @@ class ArticleTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeGroupInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeGroupInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAttributeGroupsResult = [
             $object,
             $otherObject
@@ -311,7 +314,7 @@ class ArticleTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAttributeOptionsResult = [
             $object,
             $otherObject
@@ -342,7 +345,7 @@ class ArticleTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAttributesResult = [
             $object,
             $otherObject
@@ -369,7 +372,7 @@ class ArticleTypeClientTest extends TestCase
         $id = 234;
         $attributeId = 334;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeResult = true;
 
         $this->soapClient->expects($this->once())->method('removeAttribute')->with([
@@ -391,7 +394,7 @@ class ArticleTypeClientTest extends TestCase
         $id = 234;
         $attributeGroupId = 334;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeGroupResult = true;
 
         $this->soapClient->expects($this->once())->method('removeAttributeGroup')->with([
@@ -414,7 +417,7 @@ class ArticleTypeClientTest extends TestCase
         $attributeId = 556;
         $optionId = 334;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeOptionResult = true;
 
         $this->soapClient->expects($this->once())->method('removeAttributeOption')->with([

--- a/tests/Client/Blacklist/BlackListClientTest.php
+++ b/tests/Client/Blacklist/BlackListClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Blacklist;
 
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Client/Container/ContainerClientTest.php
+++ b/tests/Client/Container/ContainerClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Container;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -11,6 +13,7 @@ use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
+use stdClass;
 
 /**
  * Class ContainerClientTest
@@ -77,7 +80,7 @@ class ContainerClientTest extends TestCase
             'some' => 'value'
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -114,7 +117,7 @@ class ContainerClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getDataResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createHashMapConfig')->willReturn($config);
@@ -139,7 +142,7 @@ class ContainerClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getDataResult = $object;
 
         $extractedData = [

--- a/tests/Client/Container/ContainerTypeClientTest.php
+++ b/tests/Client/Container/ContainerTypeClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Container;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,6 +15,7 @@ use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeGroupInterface;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeInterface;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeOptionInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
+use stdClass;
 
 /**
  * Class ContainerTypeClientTest
@@ -85,7 +88,7 @@ class ContainerTypeClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ContainerAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createContainerAttributeConfig')->willReturn($config);
@@ -116,7 +119,7 @@ class ContainerTypeClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ContainerAttributeGroupInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeGroupResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createContainerAttributeGroupConfig')->willReturn($config);
@@ -142,7 +145,7 @@ class ContainerTypeClientTest extends TestCase
         $attributeId = 55;
         $typeId = 88;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->changeAttributeTypeResult = false;
 
         $this->soapClient->expects($this->once())->method('changeAttributeType')->with([
@@ -168,7 +171,7 @@ class ContainerTypeClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createAttributeOptionResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createContainerAttributeOptionConfig')->willReturn($config);
@@ -197,7 +200,7 @@ class ContainerTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAttributeGroupsResult = [
             $object,
             $otherObject
@@ -228,7 +231,7 @@ class ContainerTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeOptionInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAttributeOptionsResult = [
             $object,
             $otherObject
@@ -259,7 +262,7 @@ class ContainerTypeClientTest extends TestCase
         $object = $this->getMockBuilder(ContainerAttributeInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ContainerAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAttributesResult = [
             $object,
             $otherObject
@@ -286,7 +289,7 @@ class ContainerTypeClientTest extends TestCase
         $id = 123;
         $attributeId = 543;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeResult = true;
 
         $this->soapClient->expects($this->once())->method('removeAttribute')->with([
@@ -306,7 +309,7 @@ class ContainerTypeClientTest extends TestCase
         $id = 123;
         $attributeGroupId = 543;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeGroupResult = true;
 
         $this->soapClient->expects($this->once())->method('removeAttributeGroup')->with([
@@ -327,7 +330,7 @@ class ContainerTypeClientTest extends TestCase
         $attributeId = 543;
         $optionId = 234;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeResult = true;
 
         $this->soapClient->expects($this->once())->method('removeAttributeOption')->with([
@@ -357,7 +360,7 @@ class ContainerTypeClientTest extends TestCase
             'some other key' => 'some other value'
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateAttributeResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createHashMapConfig')->willReturn($config);

--- a/tests/Client/Document/DocumentClientTest.php
+++ b/tests/Client/Document/DocumentClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Document;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,6 +15,7 @@ use Scn\EvalancheSoapStruct\Struct\Generic\FolderInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceTypeInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ServiceStatusInterface;
+use stdClass;
 
 /**
  * Class DocumentClientTest
@@ -82,7 +85,7 @@ class DocumentClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -110,7 +113,7 @@ class DocumentClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->copyResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -134,7 +137,7 @@ class DocumentClientTest extends TestCase
     {
         $id = 56;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->deleteResult = true;
 
         $this->soapClient->expects($this->once())->method('delete')->with(['resource_id' => $id])->willReturn($response);
@@ -154,7 +157,7 @@ class DocumentClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAllResult = [
             $object,
             $otherObject
@@ -181,7 +184,7 @@ class DocumentClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByCategoryResult = [
             $object,
             $otherObject
@@ -207,7 +210,7 @@ class DocumentClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByExternalIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -231,7 +234,7 @@ class DocumentClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByExternalIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -257,7 +260,7 @@ class DocumentClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByTypeIdResult = [
             $object,
             $otherObject
@@ -286,7 +289,7 @@ class DocumentClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(FolderInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getResourceDefaultCategoryResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createFolderInformationConfig')->willReturn($config);
@@ -309,7 +312,7 @@ class DocumentClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByTypeIdResult = [
             $object,
             $otherObject
@@ -336,7 +339,7 @@ class DocumentClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->moveResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -361,7 +364,7 @@ class DocumentClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ServiceStatusInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->isAliveResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createServiceStatusConfig')->willReturn($config);

--- a/tests/Client/Folder/FolderClientTest.php
+++ b/tests/Client/Folder/FolderClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Folder;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -10,6 +12,7 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\FolderInformationInterface;
+use stdClass;
 
 /**
  * Class FolderClientTest
@@ -71,7 +74,7 @@ class FolderClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(FolderInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createFolderInformationConfig')->willReturn($config);
@@ -95,7 +98,7 @@ class FolderClientTest extends TestCase
     {
         $id = 56;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->deleteResult = true;
 
         $this->soapClient->expects($this->once())->method('delete')->with(['category_id' => $id])->willReturn($response);
@@ -111,7 +114,7 @@ class FolderClientTest extends TestCase
         $object = $this->getMockBuilder(FolderInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(FolderInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getSubCategoriesResult = [
             $object,
             $otherObject
@@ -141,7 +144,7 @@ class FolderClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(FolderInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getDetailsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createFolderInformationConfig')->willReturn($config);

--- a/tests/Client/Form/FormClientTest.php
+++ b/tests/Client/Form/FormClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Form;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -11,6 +13,7 @@ use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Statistic\FormStatisticInterface;
+use stdClass;
 
 /**
  * Class FormClientTest
@@ -75,7 +78,7 @@ class FormClientTest extends TestCase
         $id = 123;
         $poolAttributeId = 653;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeResult = 1;
 
         $this->soapClient->expects($this->once())->method('addAttribute')->with([
@@ -98,7 +101,7 @@ class FormClientTest extends TestCase
         $id = 45;
         $optionId = 555;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeOptionResult = true;
 
         $this->soapClient->expects($this->once())->method('addAttributeOption')->with([
@@ -122,7 +125,7 @@ class FormClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createAliasResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -151,7 +154,7 @@ class FormClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAliasesResult = [
             $object,
             $otherObject
@@ -180,7 +183,7 @@ class FormClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getFormByAliasResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -208,7 +211,7 @@ class FormClientTest extends TestCase
         $object = $this->getMockBuilder(FormStatisticInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(FormStatisticInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getStatisticsResult = [
             $object,
             $otherObject
@@ -236,7 +239,7 @@ class FormClientTest extends TestCase
         $id = 123;
         $formAttributeId = 44;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeResult = false;
 
         $this->soapClient->expects($this->once())->method('removeAttribute')->with([
@@ -256,7 +259,7 @@ class FormClientTest extends TestCase
         $id = 123;
         $optionId = 44;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAttributeOptionResult = false;
 
         $this->soapClient->expects($this->once())->method('removeAttributeOption')->with([
@@ -279,7 +282,7 @@ class FormClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->renameResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -307,7 +310,7 @@ class FormClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateTemplateResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);

--- a/tests/Client/Image/ImageClientTest.php
+++ b/tests/Client/Image/ImageClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Image;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,6 +15,7 @@ use Scn\EvalancheSoapStruct\Struct\Generic\FolderInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceTypeInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ServiceStatusInterface;
+use stdClass;
 
 /**
  * Class ImageClientTest
@@ -83,7 +86,7 @@ class ImageClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -112,7 +115,7 @@ class ImageClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->copyResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -136,7 +139,7 @@ class ImageClientTest extends TestCase
     {
         $id = 56;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->deleteResult = true;
 
         $this->soapClient->expects($this->once())->method('delete')->with(['resource_id' => $id])->willReturn($response);
@@ -156,7 +159,7 @@ class ImageClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAllResult = [
             $object,
             $otherObject
@@ -183,7 +186,7 @@ class ImageClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByCategoryResult = [
             $object,
             $otherObject
@@ -209,7 +212,7 @@ class ImageClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByExternalIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -233,7 +236,7 @@ class ImageClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByExternalIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -259,7 +262,7 @@ class ImageClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByTypeIdResult = [
             $object,
             $otherObject
@@ -288,7 +291,7 @@ class ImageClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(FolderInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getResourceDefaultCategoryResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createFolderInformationConfig')->willReturn($config);
@@ -311,7 +314,7 @@ class ImageClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByTypeIdResult = [
             $object,
             $otherObject
@@ -338,7 +341,7 @@ class ImageClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->moveResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -360,7 +363,7 @@ class ImageClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ServiceStatusInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->isAliveResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createServiceStatusConfig')->willReturn($config);

--- a/tests/Client/Mailing/MailingClientTest.php
+++ b/tests/Client/Mailing/MailingClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Mailing;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -25,6 +27,7 @@ use Scn\EvalancheSoapStruct\Struct\Mailing\MailingSubjectInterface;
 use Scn\EvalancheSoapStruct\Struct\Statistic\ArticleStatisticInterface;
 use Scn\EvalancheSoapStruct\Struct\Statistic\ClientStatisticInterface;
 use Scn\EvalancheSoapStruct\Struct\Statistic\MailingStatisticInterface;
+use stdClass;
 
 /**
  * Class MailingClientTest
@@ -130,7 +133,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ClientStatisticInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getClientStatisticsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createClientStatisticConfig')->willReturn($config);
@@ -154,7 +157,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(MailingStatisticInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getStatisticsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createMailingStatisticConfig')->willReturn($config);
@@ -186,7 +189,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(MailingStatusInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MailingStatusInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getStatusResult = [
             $object,
             $otherObject
@@ -220,7 +223,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(MailingImpressionInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MailingImpressionInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getImpressionsResult = [
             $object,
             $otherObject
@@ -249,7 +252,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ServiceStatusInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->isAliveResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createServiceStatusConfig')->willReturn($config);
@@ -278,7 +281,7 @@ class MailingClientTest extends TestCase
             'some ' => 'data',
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->setConfigurationResult = $object;
 
         $this->extractor->expects($this->once())->method('extract')->with($config, $configuration)->willReturn($extractedData);
@@ -307,7 +310,7 @@ class MailingClientTest extends TestCase
             'some other subject'
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->setSubjectsResult = true;
 
         $this->soapClient->expects($this->once())->method('setSubjects')->with([
@@ -330,7 +333,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(MailingDetailInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByTypeIdResult = [
             $object
         ];
@@ -360,7 +363,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getSendableDraftsResult = [
             $object,
             $otherObject
@@ -392,7 +395,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(MailingDetailInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->sendToTargetgroupResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createMailingDetailConfig')->willReturn($config);
@@ -425,7 +428,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAllArticleImpressionProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -452,7 +455,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(MailingConfigurationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getConfigurationResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createMailingConfigurationConfig')->willReturn($config);
@@ -479,7 +482,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->moveResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -510,7 +513,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getBounceProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -538,7 +541,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(MailingSubjectInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MailingSubjectInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getSubjectsResult = [
             $object,
             $otherObject
@@ -574,7 +577,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(MailingArticleInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MailingArticleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeArticlesResult = [
             $object,
             $otherObject
@@ -609,7 +612,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getLinkClickProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -638,7 +641,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(MailingArticleInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MailingArticleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getArticlesResult = [
             $object,
             $otherObject
@@ -671,7 +674,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getClickProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -699,7 +702,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(ArticleStatisticInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ArticleStatisticInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getArticleStatisticsResult = [
             $object,
             $otherObject
@@ -730,7 +733,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getSendableDraftsByMandatorIdResult = [
             $object,
             $otherObject
@@ -757,7 +760,7 @@ class MailingClientTest extends TestCase
     {
         $id = 123;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->removeAllArticlesResult = true;
 
         $this->soapClient->expects($this->once())->method('removeAllArticles')->with(['mailing_id' => $id])->willReturn($response);
@@ -775,7 +778,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createDraftResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -807,7 +810,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getSoftbounceProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -832,7 +835,7 @@ class MailingClientTest extends TestCase
         $id = 'some Id';
         $cursor = 5;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->setResultCursorResult = false;
 
         $this->soapClient->expects($this->once())->method('setResultCursor')->with(
@@ -860,7 +863,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getImpressionProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -891,7 +894,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getRecipientsProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -918,7 +921,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobResultInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getResultsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobResultConfig')->willReturn($config);
@@ -948,7 +951,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getMultipleImpressionProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -979,7 +982,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAllLinkClickProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -1009,7 +1012,7 @@ class MailingClientTest extends TestCase
 
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addArticlesResult = $articles;
 
         $extractedData = [
@@ -1053,7 +1056,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getHardbounceProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -1084,7 +1087,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getMultipleClickProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -1116,7 +1119,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getArticleImpressionProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -1148,7 +1151,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getUnsubscriptionProfilesResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -1177,7 +1180,7 @@ class MailingClientTest extends TestCase
             4,
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->sendToProfilesResult = $profileIds;
 
         $this->soapClient->expects($this->once())->method('sendToProfiles')->with([
@@ -1202,7 +1205,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(MailingDetailInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getDetailsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createMailingDetailConfig')->willReturn($config);
@@ -1228,7 +1231,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getJobInformationResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -1251,7 +1254,7 @@ class MailingClientTest extends TestCase
     {
         $id = '234';
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getResultCursorResult = 'some return string';
 
         $this->soapClient->expects($this->once())->method('getResultCursor')->with(['job_id' => $id])->willReturn($response);
@@ -1274,7 +1277,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->renameResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -1304,7 +1307,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(MailingClickInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MailingClickInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getClicksResult = [
             $object,
             $otherObject
@@ -1334,7 +1337,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByTypeIdResult = [
             $object,
             $otherObject
@@ -1357,7 +1360,7 @@ class MailingClientTest extends TestCase
     {
         $id = 56;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->deleteResult = true;
 
         $this->soapClient->expects($this->once())->method('delete')->with(['resource_id' => $id])->willReturn($response);
@@ -1377,7 +1380,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->copyResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -1405,7 +1408,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAllResult = [
             $object,
             $otherObject
@@ -1432,7 +1435,7 @@ class MailingClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByCategoryResult = [
             $object,
             $otherObject
@@ -1458,7 +1461,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByExternalIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -1482,7 +1485,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(FolderInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getResourceDefaultCategoryResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createFolderInformationConfig')->willReturn($config);
@@ -1506,7 +1509,7 @@ class MailingClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByExternalIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);

--- a/tests/Client/Mailing/MailingTemplateClientTest.php
+++ b/tests/Client/Mailing/MailingTemplateClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Mailing;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -390,7 +392,7 @@ class MailingTemplateClientTest extends TestCase
             'some ' => 'data',
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->setConfigurationResult = $object;
 
         $this->extractor->expects($this->once())
@@ -472,7 +474,7 @@ class MailingTemplateClientTest extends TestCase
             'some ' => 'data',
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->setSourcesResult = $object;
 
         $this->extractor->expects($this->once())

--- a/tests/Client/Mandator/MandatorClientTest.php
+++ b/tests/Client/Mandator/MandatorClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Mandator;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -10,6 +12,7 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mandator\MandatorInterface;
+use stdClass;
 
 /**
  * Class MandatorClientTest
@@ -63,7 +66,7 @@ class MandatorClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(MandatorInterface::class)->getMock();
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getByIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createMandatorConfig')
@@ -93,13 +96,13 @@ class MandatorClientTest extends TestCase
         $object = $this->getMockBuilder(MandatorInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MandatorInterface::class)->getMock();
 
-        $list = new \stdClass();
+        $list = new stdClass();
         $list->item = [
             $object,
             $otherObject
         ];
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getListResult = $list;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createMandatorConfig')

--- a/tests/Client/Marketplace/MarketplaceClientTest.php
+++ b/tests/Client/Marketplace/MarketplaceClientTest.php
@@ -11,10 +11,12 @@ use Scn\EvalancheSoapApiConnector\Extractor\ExtractorInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
+use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Marketplace\CategoryInterface;
 use Scn\EvalancheSoapStruct\Struct\Marketplace\ProductInterface;
+use stdClass;
 
-class MarketplaceClientTest extends \Scn\EvalancheSoapApiConnector\TestCase
+class MarketplaceClientTest extends TestCase
 {
 
     /**
@@ -65,7 +67,7 @@ class MarketplaceClientTest extends \Scn\EvalancheSoapApiConnector\TestCase
     {
         $languageId = LanguageEnum::ES;
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->items = [
             $this->getMockBuilder(CategoryInterface::class)->getMock(),
         ];
@@ -98,7 +100,7 @@ class MarketplaceClientTest extends \Scn\EvalancheSoapApiConnector\TestCase
         $categoryId = 123;
         $languageId = LanguageEnum::ES;
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->items = [
             $this->getMockBuilder(ProductInterface::class)->getMock(),
         ];
@@ -136,7 +138,7 @@ class MarketplaceClientTest extends \Scn\EvalancheSoapApiConnector\TestCase
         $languageId = LanguageEnum::EN;
 
         $result_string = 'my result';
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->RecipeId = $result_string;
 
         $this->soapClient->expects($this->once())->method('purchaseProduct')

--- a/tests/Client/Milestone/MilestoneClientTest.php
+++ b/tests/Client/Milestone/MilestoneClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Milestone;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -10,6 +12,7 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
+use stdClass;
 
 /**
  * Class MilestoneClientTest
@@ -79,7 +82,7 @@ class MilestoneClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = $object;
 
         $this->hydratorConfigFactory

--- a/tests/Client/Pool/PoolClientTest.php
+++ b/tests/Client/Pool/PoolClientTest.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Pool;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Scn\EvalancheSoapApiConnector\EvalancheSoapClient;
 use Scn\EvalancheSoapApiConnector\Extractor\ExtractorInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Pool\PoolAttributeInterface;
+use stdClass;
 
 /**
  * Class PoolClientTest
@@ -23,7 +27,7 @@ class PoolClientTest extends TestCase
     private $subject;
 
     /**
-     * @var \Scn\EvalancheSoapApiConnector\EvalancheSoapClient|MockObject
+     * @var EvalancheSoapClient|MockObject
      */
     private $soapClient;
 
@@ -74,7 +78,7 @@ class PoolClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(PoolAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createPoolAttributeConfig')->willReturn($config);
@@ -108,7 +112,7 @@ class PoolClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(PoolAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addAttributeOptionsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createPoolAttributeConfig')->willReturn($config);
@@ -134,7 +138,7 @@ class PoolClientTest extends TestCase
         $id = 345;
         $attributeId = 456;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->deleteAttributeResult = true;
 
         $this->soapClient->expects($this->once())
@@ -161,7 +165,7 @@ class PoolClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(PoolAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->deleteAttributeOptionResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createPoolAttributeConfig')->willReturn($config);
@@ -190,7 +194,7 @@ class PoolClientTest extends TestCase
         $object = $this->getMockBuilder(PoolAttributeInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(PoolAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getAttributesResult = [
             $object,
             $otherObject
@@ -222,7 +226,7 @@ class PoolClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(PoolAttributeInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateAttributeOptionResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createPoolAttributeConfig')->willReturn($config);

--- a/tests/Client/Pool/PoolDataMinerClientTest.php
+++ b/tests/Client/Pool/PoolDataMinerClientTest.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Pool;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Scn\EvalancheSoapApiConnector\EvalancheSoapClient;
 use Scn\EvalancheSoapApiConnector\Extractor\ExtractorInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
+use stdClass;
 
 /**
  * Class PoolDataMinerClientTest
@@ -24,7 +28,7 @@ class PoolDataMinerClientTest extends TestCase
     private $subject;
 
     /**
-     * @var \Scn\EvalancheSoapApiConnector\EvalancheSoapClient|MockObject
+     * @var EvalancheSoapClient|MockObject
      */
     private $soapClient;
 
@@ -66,7 +70,7 @@ class PoolDataMinerClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $resonse = new \stdClass();
+        $resonse = new stdClass();
         $resonse->renameResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);

--- a/tests/Client/Profile/ProfileClientTest.php
+++ b/tests/Client/Profile/ProfileClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Profile;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -20,6 +22,7 @@ use Scn\EvalancheSoapStruct\Struct\Mailing\MailingStatusInterface;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileActivityScoreInterface;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileBounceStatusInterface;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileGroupScoreInterface;
+use stdClass;
 
 /**
  * Class ProfileClientTest
@@ -114,7 +117,7 @@ class ProfileClientTest extends TestCase
         $score = 12;
         $title = 'some title';
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addScoreResult = true;
 
         $this->soapClient->expects($this->once())->method('addScore')->with([
@@ -136,7 +139,7 @@ class ProfileClientTest extends TestCase
         $id = 123;
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createResult = 345;
 
         $extractedData = [
@@ -173,7 +176,7 @@ class ProfileClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByPoolResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -201,7 +204,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(ProfileGroupScoreInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ProfileGroupScoreInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getScoresResult = [
             $object,
             $otherObject
@@ -226,7 +229,7 @@ class ProfileClientTest extends TestCase
         $id = 234;
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateByPoolResult = true;
 
         $extractedData = [
@@ -268,7 +271,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(ProfileBounceStatusInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ProfileBounceStatusInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getBouncesResult = [
             $otherObject,
             $object
@@ -308,7 +311,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(HashMapInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getUnsubscriptionsResult = [
             $otherObject,
             $object
@@ -339,7 +342,7 @@ class ProfileClientTest extends TestCase
         $id = 234;
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->mergeByTargetGroupResult = true;
 
         $extractedData = [
@@ -372,7 +375,7 @@ class ProfileClientTest extends TestCase
         $id = 234;
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->mergeByIdResult = true;
 
         $extractedData = [
@@ -397,14 +400,14 @@ class ProfileClientTest extends TestCase
             'mergeByIdResult'
         )->willReturn($response->mergeByIdResult);
 
-        $this->assertTrue($this->subject->mergeById($id, $hashMap));
+        $this->assertTrue($this->subject->mergeById((string) $id, $hashMap));
     }
 
     public function testGetResultCursorByJobIdCanReturnString()
     {
         $id = 'some job id';
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getResultCursorResult = 'some return string';
 
         $this->soapClient->expects($this->once())->method('getResultCursor')->with(['job_id' => $id])->willReturn($response);
@@ -431,7 +434,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(TargetGroupMemberShipInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(TargetGroupMemberShipInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->isInTargetgroupsResult = [
             $object,
             $otherObject
@@ -468,7 +471,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(HashMapInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getGrantedPermissionsResult = [
             $object,
             $otherObject
@@ -500,7 +503,7 @@ class ProfileClientTest extends TestCase
     {
         $id = 8;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->revokeTrackingResult = true;
 
         $this->soapClient->expects($this->once())->method('revokeTracking')->with(['profile_id' => $id])->willReturn($response);
@@ -523,7 +526,7 @@ class ProfileClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByTargetGroupResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -550,7 +553,7 @@ class ProfileClientTest extends TestCase
         $value = 'some value';
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->mergeByKeyResult = true;
 
         $extractedData = [
@@ -586,7 +589,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceTypeInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getTypeIdsResult = [
             $object,
             $otherObject
@@ -610,7 +613,7 @@ class ProfileClientTest extends TestCase
     {
         $id = 8;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->grantPermissionResult = true;
 
         $this->soapClient->expects($this->once())->method('grantPermission')->with(['profile_id' => $id])->willReturn($response);
@@ -627,7 +630,7 @@ class ProfileClientTest extends TestCase
         $id = 234;
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateByTargetGroupResult = true;
 
         $extractedData = [
@@ -675,7 +678,7 @@ class ProfileClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(MassUpdateResultInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->massUpdateResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createMassUpdateResultConfig')->willReturn($config);
@@ -707,7 +710,7 @@ class ProfileClientTest extends TestCase
         $value = 'some value';
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateByKeyResult = true;
 
         $extractedData = [
@@ -742,7 +745,7 @@ class ProfileClientTest extends TestCase
         $id = 'some Id';
         $cursor = 5;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->setResultCursorResult = false;
 
         $this->soapClient->expects($this->once())->method('setResultCursor')->with(
@@ -764,7 +767,7 @@ class ProfileClientTest extends TestCase
         $id = 234;
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->updateByIdResult = true;
 
         $extractedData = [
@@ -806,7 +809,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(HashMapInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByKeyResult = [
             $otherObject,
             $object
@@ -841,7 +844,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(MailingStatusInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(MailingStatusInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getMailingStatusResult = [
             $otherObject,
             $object
@@ -871,7 +874,7 @@ class ProfileClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getJobInformationResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobHandleConfig')->willReturn($config);
@@ -904,7 +907,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(HashMapInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getModifiedProfilesResult = [
             $object,
             $otherObject
@@ -937,7 +940,7 @@ class ProfileClientTest extends TestCase
         $id = 234;
         $hashMap = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->mergeByPoolResult = null;
 
         $extractedData = [
@@ -967,7 +970,7 @@ class ProfileClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobResultInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getResultsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createJobResultConfig')->willReturn($config);
@@ -990,7 +993,7 @@ class ProfileClientTest extends TestCase
     {
         $id = 8;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->revokePermissionResult = true;
 
         $this->soapClient->expects($this->once())->method('revokePermission')->with(['profile_id' => $id])->willReturn($response);
@@ -1012,7 +1015,7 @@ class ProfileClientTest extends TestCase
             5
         ];
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->deleteResult = true;
 
         $this->soapClient->expects($this->once())->method('delete')->with(['profile_ids' => $profileIds])->willReturn($response);
@@ -1037,7 +1040,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(ProfileActivityScoreInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ProfileActivityScoreInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getActivityScoringHistoryResult = [
             $object,
             $otherObject
@@ -1074,7 +1077,7 @@ class ProfileClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(HashMapInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByIdResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createHashMapConfig')->willReturn($config);
@@ -1106,7 +1109,7 @@ class ProfileClientTest extends TestCase
         ];
         $doUpdate = true;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->untagWithOptionResult = true;
 
         $this->soapClient->expects($this->once())->method('untagWithOption')->with([
@@ -1134,7 +1137,7 @@ class ProfileClientTest extends TestCase
         ];
         $doUpdate = true;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->tagWithOptionResult = true;
 
         $this->soapClient->expects($this->once())->method('tagWithOption')->with([
@@ -1162,7 +1165,7 @@ class ProfileClientTest extends TestCase
         $object = $this->getMockBuilder(ProfileTrackingHistoryInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ProfileTrackingHistoryInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getTrackingHistoryResult = [
             $object,
             $otherObject
@@ -1194,7 +1197,7 @@ class ProfileClientTest extends TestCase
         $profileId = 333;
         $milestoneId = 444;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->setMilestoneResult = true;
 
         $this->soapClient->expects($this->once())->method('setMilestone')->with(
@@ -1219,7 +1222,7 @@ class ProfileClientTest extends TestCase
         $timestampStart = 123456;
         $timestampEnd = 234567;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->hasMilestoneResult = true;
 
         $this->soapClient->expects($this->once())->method('hasMilestone')->with(
@@ -1252,7 +1255,7 @@ class ProfileClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(JobHandleInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getByMilestoneResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())

--- a/tests/Client/Report/ReportClientTest.php
+++ b/tests/Client/Report/ReportClientTest.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Report;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Scn\EvalancheSoapApiConnector\EvalancheSoapClient;
 use Scn\EvalancheSoapApiConnector\Extractor\ExtractorInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
+use stdClass;
 
 /**
  * Class ReportClientTest
@@ -22,7 +26,7 @@ class ReportClientTest extends TestCase
     private $subject;
 
     /**
-     * @var \Scn\EvalancheSoapApiConnector\EvalancheSoapClient|MockObject
+     * @var EvalancheSoapClient|MockObject
      */
     private $soapClient;
 
@@ -61,7 +65,7 @@ class ReportClientTest extends TestCase
         $id = 123;
         $reportId = 555;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->addResourceToReportResult = true;
 
         $this->soapClient->expects($this->once())->method('addResourceToReport')->with([

--- a/tests/Client/Scoring/ScoringClientTest.php
+++ b/tests/Client/Scoring/ScoringClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Scoring;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -10,6 +12,7 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Scoring\ScoringGroupDetailInterface;
+use stdClass;
 
 /**
  * Class ScoringClientTest
@@ -64,7 +67,7 @@ class ScoringClientTest extends TestCase
         $object = $this->getMockBuilder(ScoringGroupDetailInterface::class);
         $otherObject = $this->getMockBuilder(ScoringGroupDetailInterface::class);
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getGroupsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createScoringGroupDetailConfig')->willReturn($config);

--- a/tests/Client/Smartlink/SmartLinkClientTest.php
+++ b/tests/Client/Smartlink/SmartLinkClientTest.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Smartlink;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Scn\EvalancheSoapApiConnector\EvalancheSoapClient;
 use Scn\EvalancheSoapApiConnector\Extractor\ExtractorInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\SmartLink\SmartLinkInterface;
+use stdClass;
 
 /**
  * Class SmartLinkClientTest
@@ -24,7 +28,7 @@ class SmartLinkClientTest extends TestCase
     private $subject;
 
     /**
-     * @var \Scn\EvalancheSoapApiConnector\EvalancheSoapClient|MockObject
+     * @var EvalancheSoapClient|MockObject
      */
     private $soapClient;
 
@@ -66,7 +70,7 @@ class SmartLinkClientTest extends TestCase
 
         $result_string = 'some string';
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->createLinkResult = $result_string;
 
         $this->soapClient->expects($this->once())->method('createLink')->with([
@@ -90,7 +94,7 @@ class SmartLinkClientTest extends TestCase
         $object = $this->getMockBuilder(SmartLinkInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(SmartLinkInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->getTrackingUrlsResult = [
             $object,
             $otherObject

--- a/tests/Client/TargetGroup/TargetGroupClientTest.php
+++ b/tests/Client/TargetGroup/TargetGroupClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\TargetGroup;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -11,6 +13,7 @@ use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\TargetGroup\TargetGroupDetailInterface;
+use stdClass;
 
 /**
  * Class TargetGroupClientTest
@@ -73,7 +76,7 @@ class TargetGroupClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createByOptionResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createResourceInformationConfig')->willReturn($config);
@@ -103,7 +106,7 @@ class TargetGroupClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(TargetGroupDetailInterface::class)->getMock();
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->createByOptionResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createTargetGroupDetailConfig')->willReturn($config);

--- a/tests/Client/User/UserClientTest.php
+++ b/tests/Client/User/UserClientTest.php
@@ -1,14 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\User;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Scn\EvalancheSoapApiConnector\EvalancheSoapClient;
 use Scn\EvalancheSoapApiConnector\Extractor\ExtractorInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\User\UserInterface;
+use stdClass;
 
 /**
  * Class UserClientTest
@@ -23,7 +27,7 @@ class UserClientTest extends TestCase
     private $subject;
 
     /**
-     * @var \Scn\EvalancheSoapApiConnector\EvalancheSoapClient|MockObject
+     * @var EvalancheSoapClient|MockObject
      */
     private $soapClient;
 
@@ -62,7 +66,7 @@ class UserClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(UserInterface::class)->getMock();
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getByUsernameResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createUserConfig')->willReturn($config);
@@ -85,13 +89,13 @@ class UserClientTest extends TestCase
         $object = $this->getMockBuilder(UserInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(UserInterface::class)->getMock();
 
-        $list = new \stdClass();
+        $list = new stdClass();
         $list->item = [
             $object,
             $otherObject
         ];
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getAllResult = $list;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createUserConfig')->willReturn($config);
@@ -111,7 +115,7 @@ class UserClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(UserInterface::class)->getMock();
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->updateResult = $object;
 
         $expectedExtractor = [

--- a/tests/Client/Webhook/WebhookClientTest.php
+++ b/tests/Client/Webhook/WebhookClientTest.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Webhook;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use Scn\EvalancheSoapApiConnector\EvalancheSoapClient;
 use Scn\EvalancheSoapApiConnector\Extractor\ExtractorInterface;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigFactoryInterface;
 use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
@@ -21,7 +24,7 @@ class WebhookClientTest extends TestCase
     private $subject;
 
     /**
-     * @var \Scn\EvalancheSoapApiConnector\EvalancheSoapClient|MockObject
+     * @var EvalancheSoapClient|MockObject
      */
     private $soapClient;
 

--- a/tests/Client/Workflow/WorkflowClientTest.php
+++ b/tests/Client/Workflow/WorkflowClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Client\Workflow;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -11,6 +13,7 @@ use Scn\EvalancheSoapApiConnector\Mapper\ResponseMapperInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\Workflow\WorkflowDetailInterface;
+use stdClass;
 
 /**
  * Class WorkflowClientTest
@@ -75,7 +78,7 @@ class WorkflowClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getByEndateRangeResult = [
             $object,
             $otherObject
@@ -108,7 +111,7 @@ class WorkflowClientTest extends TestCase
         $object = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
         $otherObject = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getByEndDateRangeResult = [
             $object,
             $otherObject
@@ -138,7 +141,7 @@ class WorkflowClientTest extends TestCase
         $config = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
         $object = $this->getMockBuilder(WorkflowDetailInterface::class)->getMock();
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->getDetailsResult = $object;
 
         $this->hydratorConfigFactory->expects($this->once())->method('createWorkflowDetailConfig')->willReturn($config);
@@ -160,7 +163,7 @@ class WorkflowClientTest extends TestCase
             6
         ];
 
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->pushProfilesIntoCampaignResult = true;
 
         $this->soapClient->expects($this->once())->method('pushProfilesIntoCampaign')->with([
@@ -174,13 +177,13 @@ class WorkflowClientTest extends TestCase
 
     public function testCreateConfiguredReturnsResourceInformation()
     {
-        $name = 123;
+        $name = 'some-name';
         $schemaVersion = 1;
         $workflowConfiguration = 'my config';
         $categoryId = 456;
 
         $resourceInformation = $this->getMockBuilder(ResourceInformationInterface::class)->getMock();
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->createResult = $resourceInformation;
 
         $this->soapClient->expects($this->once())->method('createConfigured')->with([
@@ -213,7 +216,7 @@ class WorkflowClientTest extends TestCase
         $workflowId = 42;
 
         $result_string = 'my result';
-        $result = new \stdClass();
+        $result = new stdClass();
         $result->createResult = $result_string;
 
         $this->soapClient->expects($this->once())->method('export')->with([

--- a/tests/EvalancheConfigTest.php
+++ b/tests/EvalancheConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector;
 
 /**

--- a/tests/EvalancheConnectionTest.php
+++ b/tests/EvalancheConnectionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector;
 
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/EvalancheSoapClientTest.php
+++ b/tests/EvalancheSoapClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector;
 
 use Scn\EvalancheSoapApiConnector\Exception\DebugRequestException;

--- a/tests/Extractor/ExtractorTest.php
+++ b/tests/Extractor/ExtractorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Extractor;
 
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Hydrator/Config/Account/AccountConfigTest.php
+++ b/tests/Hydrator/Config/Account/AccountConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Account;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Account/AccountingItemConfigTest.php
+++ b/tests/Hydrator/Config/Account/AccountingItemConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Account;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Account/AccountingTypeConfigTest.php
+++ b/tests/Hydrator/Config/Account/AccountingTypeConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Account;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Account/DiscountConfigTest.php
+++ b/tests/Hydrator/Config/Account/DiscountConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Account;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Blacklist/BlackListConfigTest.php
+++ b/tests/Hydrator/Config/Blacklist/BlackListConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Blacklist;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Blacklist/BlackListItemConfigTest.php
+++ b/tests/Hydrator/Config/Blacklist/BlackListItemConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Blacklist;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Container/ContainerAttributeConfigTest.php
+++ b/tests/Hydrator/Config/Container/ContainerAttributeConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Container;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Container\ContainerAttributeConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Container;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeInterface;
 

--- a/tests/Hydrator/Config/Container/ContainerAttributeGroupConfigTest.php
+++ b/tests/Hydrator/Config/Container/ContainerAttributeGroupConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Container;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Container\ContainerAttributeGroupConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Container;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeGroupInterface;
 

--- a/tests/Hydrator/Config/Container/ContainerAttributeOptionConfigTest.php
+++ b/tests/Hydrator/Config/Container/ContainerAttributeOptionConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Container;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Container\ContainerAttributeOptionConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Container;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeOptionInterface;
 

--- a/tests/Hydrator/Config/Container/ContainerAttributeRoleTypeConfigTest.php
+++ b/tests/Hydrator/Config/Container/ContainerAttributeRoleTypeConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Container;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Container\ContainerAttributeRoleTypeConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Container;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Container\ContainerAttributeRoleTypeInterface;
 

--- a/tests/Hydrator/Config/Generic/FolderInformationConfigTest.php
+++ b/tests/Hydrator/Config/Generic/FolderInformationConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\FolderInformationConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\FolderInformationInterface;
 

--- a/tests/Hydrator/Config/Generic/HashMapConfigTest.php
+++ b/tests/Hydrator/Config/Generic/HashMapConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\HashMapConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
 

--- a/tests/Hydrator/Config/Generic/HashMapItemConfigTest.php
+++ b/tests/Hydrator/Config/Generic/HashMapItemConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Generic/JobHandleConfigTest.php
+++ b/tests/Hydrator/Config/Generic/JobHandleConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobHandleConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\JobHandleInterface;
 

--- a/tests/Hydrator/Config/Generic/JobResultConfigTest.php
+++ b/tests/Hydrator/Config/Generic/JobResultConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobResultConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\JobResultInterface;
 

--- a/tests/Hydrator/Config/Generic/MassUpdateResultConfigTest.php
+++ b/tests/Hydrator/Config/Generic/MassUpdateResultConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\MassUpdateResultConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\MassUpdateResultInterface;
 

--- a/tests/Hydrator/Config/Generic/ResourceInformationConfigTest.php
+++ b/tests/Hydrator/Config/Generic/ResourceInformationConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\ResourceInformationConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
 

--- a/tests/Hydrator/Config/Generic/ResourceTypeInformationConfigTest.php
+++ b/tests/Hydrator/Config/Generic/ResourceTypeInformationConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\ResourceTypeInformationConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceTypeInformationInterface;
 

--- a/tests/Hydrator/Config/Generic/ServiceStatusConfigTest.php
+++ b/tests/Hydrator/Config/Generic/ServiceStatusConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Generic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\ServiceStatusConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Generic\ServiceStatusInterface;
 

--- a/tests/Hydrator/Config/HydratorConfigFactoryTest.php
+++ b/tests/Hydrator/Config/HydratorConfigFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config;
 
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Account\AccountConfig;

--- a/tests/Hydrator/Config/Mailing/MailingArticleConfigTest.php
+++ b/tests/Hydrator/Config/Mailing/MailingArticleConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mailing;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing\MailingArticleConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mailing\MailingArticleInterface;
 

--- a/tests/Hydrator/Config/Mailing/MailingClickConfigTest.php
+++ b/tests/Hydrator/Config/Mailing/MailingClickConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mailing;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing\MailingClickConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mailing\MailingClickInterface;
 

--- a/tests/Hydrator/Config/Mailing/MailingConfigurationConfigTest.php
+++ b/tests/Hydrator/Config/Mailing/MailingConfigurationConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mailing;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing\MailingConfigurationConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mailing\MailingConfigurationInterface;
 

--- a/tests/Hydrator/Config/Mailing/MailingDetailConfigTest.php
+++ b/tests/Hydrator/Config/Mailing/MailingDetailConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mailing;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing\MailingDetailConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mailing\MailingDetailInterface;
 

--- a/tests/Hydrator/Config/Mailing/MailingImpressionConfigTest.php
+++ b/tests/Hydrator/Config/Mailing/MailingImpressionConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mailing;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing\MailingImpressionConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mailing\MailingImpressionInterface;
 

--- a/tests/Hydrator/Config/Mailing/MailingStatusConfigTest.php
+++ b/tests/Hydrator/Config/Mailing/MailingStatusConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mailing;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing\MailingStatusConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mailing\MailingStatusInterface;
 

--- a/tests/Hydrator/Config/Mailing/MailingSubjectConfigTest.php
+++ b/tests/Hydrator/Config/Mailing/MailingSubjectConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mailing;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing\MailingSubjectConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mailing;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mailing\MailingSubjectInterface;
 

--- a/tests/Hydrator/Config/MailingTemplate/MailingTemplateConfigurationConfigTest.php
+++ b/tests/Hydrator/Config/MailingTemplate/MailingTemplateConfigurationConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\MailingTemplate;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\MailingTemplate\MailingTemplateConfigurationConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\MailingTemplate;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\MailingTemplate\MailingTemplateConfigurationInterface;
 

--- a/tests/Hydrator/Config/Mandator/MandatorConfigTest.php
+++ b/tests/Hydrator/Config/Mandator/MandatorConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Mandator;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Mandator\MandatorConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Mandator;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Mandator\MandatorInterface;
 

--- a/tests/Hydrator/Config/Pool/PoolAttributeConfigTest.php
+++ b/tests/Hydrator/Config/Pool/PoolAttributeConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Pool;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Pool\PoolAttributeConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Pool;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Pool\PoolAttributeInterface;
 

--- a/tests/Hydrator/Config/Pool/PoolAttributeOptionConfigTest.php
+++ b/tests/Hydrator/Config/Pool/PoolAttributeOptionConfigTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Pool;
 
 use Scn\EvalancheSoapApiConnector\TestCase;

--- a/tests/Hydrator/Config/Profile/ProfileActivityScoreConfigTest.php
+++ b/tests/Hydrator/Config/Profile/ProfileActivityScoreConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Profile;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile\ProfileActivityScoreConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileActivityScoreInterface;
 

--- a/tests/Hydrator/Config/Profile/ProfileBounceStatusConfigTest.php
+++ b/tests/Hydrator/Config/Profile/ProfileBounceStatusConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Profile;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile\ProfileBounceStatusConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileBounceStatusInterface;
 

--- a/tests/Hydrator/Config/Profile/ProfileGroupScoreConfigTest.php
+++ b/tests/Hydrator/Config/Profile/ProfileGroupScoreConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Profile;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile\ProfileGroupScoreConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileGroupScoreInterface;
 

--- a/tests/Hydrator/Config/Profile/ProfileTrackingHistoryConfigTest.php
+++ b/tests/Hydrator/Config/Profile/ProfileTrackingHistoryConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Profile;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile\ProfileTrackingHistoryConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileTrackingHistoryInterface;
 

--- a/tests/Hydrator/Config/Scoring/ScoringGroupDetailConfigTest.php
+++ b/tests/Hydrator/Config/Scoring/ScoringGroupDetailConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Scoring;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Scoring\ScoringGroupDetailConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Scoring;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Scoring\ScoringGroupDetailInterface;
 

--- a/tests/Hydrator/Config/SmartLink/SmartLinkConfigTest.php
+++ b/tests/Hydrator/Config/SmartLink/SmartLinkConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\SmartLink;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\SmartLink\SmartLinkConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\SmartLink;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\SmartLink\SmartLinkInterface;
 

--- a/tests/Hydrator/Config/Statistic/ArticleStatisticConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/ArticleStatisticConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\ArticleStatisticConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\ArticleStatisticInterface;
 

--- a/tests/Hydrator/Config/Statistic/ArticleStatisticItemConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/ArticleStatisticItemConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\ArticleStatisticItemConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\ArticleStatisticItemInterface;
 

--- a/tests/Hydrator/Config/Statistic/BrowserStatisticItemConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/BrowserStatisticItemConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\BrowserStatisticItemConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\BrowserStatisticItemInterface;
 

--- a/tests/Hydrator/Config/Statistic/ClientStatisticConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/ClientStatisticConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\ClientStatisticConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\ClientStatisticInterface;
 

--- a/tests/Hydrator/Config/Statistic/DeviceStatisticItemConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/DeviceStatisticItemConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\DeviceStatisticItemConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\DeviceStatisticItemInterface;
 

--- a/tests/Hydrator/Config/Statistic/FormStatisticConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/FormStatisticConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\FormStatisticConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\FormStatisticInterface;
 

--- a/tests/Hydrator/Config/Statistic/FormatStatisticItemConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/FormatStatisticItemConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\FormatStatisticItemConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\FormatStatisticItemInterface;
 

--- a/tests/Hydrator/Config/Statistic/LinkStatisticItemConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/LinkStatisticItemConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\LinkStatisticItemConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\LinkStatisticItem;
 

--- a/tests/Hydrator/Config/Statistic/MailClientStatisticItemConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/MailClientStatisticItemConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\MailClientStatisticItemConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\MailClientStatisticItem;
 

--- a/tests/Hydrator/Config/Statistic/MailingStatisticConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/MailingStatisticConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\MailingStatisticConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\MailingStatisticInterface;
 

--- a/tests/Hydrator/Config/Statistic/MediaStatisticItemConfigTest.php
+++ b/tests/Hydrator/Config/Statistic/MediaStatisticItemConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Statistic;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\MediaStatisticItemConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\MediaStatisticItemInterface;
 

--- a/tests/Hydrator/Config/TargetGroup/TargetGroupDetailConfigTest.php
+++ b/tests/Hydrator/Config/TargetGroup/TargetGroupDetailConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\TargetGroup;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\TargetGroup\TargetGroupDetailConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\TargetGroup;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\TargetGroup\TargetGroupDetailInterface;
 

--- a/tests/Hydrator/Config/TargetGroup/TargetGroupMemberShipConfigTest.php
+++ b/tests/Hydrator/Config/TargetGroup/TargetGroupMemberShipConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\TargetGroup;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\TargetGroup\TargetGroupMemberShipConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\TargetGroup;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\TargetGroup\TargetGroupMemberShipInterface;
 

--- a/tests/Hydrator/Config/User/UserConfigTest.php
+++ b/tests/Hydrator/Config/User/UserConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\User;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\User\UserConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\User;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\User\UserInterface;
 

--- a/tests/Hydrator/Config/Workflow/WorkflowDetailConfigTest.php
+++ b/tests/Hydrator/Config/Workflow/WorkflowDetailConfigTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Scn\EvalancheSoapApiConnector\Hydrator\Workflow;
+declare(strict_types=1);
 
-use Scn\EvalancheSoapApiConnector\Hydrator\Config\Workflow\WorkflowDetailConfig;
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Workflow;
+
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Workflow\WorkflowDetailInterface;
 

--- a/tests/Hydrator/Property/ArrayOfObjectValueTest.php
+++ b/tests/Hydrator/Property/ArrayOfObjectValueTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Property;
 
+use Closure;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\MailClientStatisticItemConfig;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\MailClientStatisticItemInterface;
+use stdClass;
 
 /**
  * Class ArrayOfObjectValueTest
@@ -15,7 +19,7 @@ class ArrayOfObjectValueTest extends TestCase
 {
     public function testEverything()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->item = [
             'some thing' => 'fine'
         ];
@@ -36,13 +40,13 @@ class ArrayOfObjectValueTest extends TestCase
 
         $set = ArrayOfObjectValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayOfObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertSame($testValue->item, $dummy->getValue());
         static::assertSame($testValue->item, $get('value'));
@@ -50,7 +54,7 @@ class ArrayOfObjectValueTest extends TestCase
 
     public function testEverythingIfItemNotArray()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->item = 'fine';
 
         $dummy = new class {
@@ -69,13 +73,13 @@ class ArrayOfObjectValueTest extends TestCase
 
         $set = ArrayOfObjectValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayOfObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertSame([$testValue->item], $dummy->getValue());
         static::assertSame([$testValue->item], $get('value'));
@@ -101,13 +105,13 @@ class ArrayOfObjectValueTest extends TestCase
 
         $set = ArrayOfObjectValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayOfObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertSame([], $dummy->getValue());
         static::assertSame([], $get('value'));
@@ -115,15 +119,15 @@ class ArrayOfObjectValueTest extends TestCase
 
     public function testContainsHydratedObjects()
     {
-        $firstObject = new \stdClass();
+        $firstObject = new stdClass();
         $firstObject->description = 'some thing';
         $firstObject->count = 456;
 
-        $secondObject = new \stdClass();
+        $secondObject = new stdClass();
         $secondObject->description = 'some thing other';
         $secondObject->count = 4561;
 
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->item = [$firstObject, $secondObject];
 
         $dummy = new class {
@@ -142,24 +146,24 @@ class ArrayOfObjectValueTest extends TestCase
 
         $set = ArrayOfObjectValue::set('value', new MailClientStatisticItemConfig());
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayOfObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertContainsOnlyInstancesOf(MailClientStatisticItemInterface::class, $dummy->getValue());
     }
 
     public function testContainsHydratedObjectsIfValueIsArray()
     {
-        $firstObject = new \stdClass();
+        $firstObject = new stdClass();
         $firstObject->description = 'some thing';
         $firstObject->count = 456;
 
-        $secondObject = new \stdClass();
+        $secondObject = new stdClass();
         $secondObject->description = 'some thing other';
         $secondObject->count = 4561;
 
@@ -181,13 +185,13 @@ class ArrayOfObjectValueTest extends TestCase
 
         $set = ArrayOfObjectValue::set('value', new MailClientStatisticItemConfig());
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayOfObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertContainsOnlyInstancesOf(MailClientStatisticItemInterface::class, $dummy->getValue());
     }

--- a/tests/Hydrator/Property/ArrayValueTest.php
+++ b/tests/Hydrator/Property/ArrayValueTest.php
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Property;
 
+use Closure;
 use Scn\EvalancheSoapApiConnector\TestCase;
+use stdClass;
 
 /**
  * Class ArrayValueTest
@@ -13,7 +17,7 @@ class ArrayValueTest extends TestCase
 {
     public function testEverything()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->item = [
             'some thing' => 'fine'
         ];
@@ -34,13 +38,13 @@ class ArrayValueTest extends TestCase
 
         $set = ArrayValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertSame($testValue->item, $dummy->getValue());
         static::assertSame($testValue->item, $get('value'));
@@ -48,7 +52,7 @@ class ArrayValueTest extends TestCase
 
     public function testEverythingIfItemNotArray()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->item = 'fine';
 
         $dummy = new class {
@@ -67,13 +71,13 @@ class ArrayValueTest extends TestCase
 
         $set = ArrayValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertSame([$testValue->item], $dummy->getValue());
         static::assertSame([$testValue->item], $get('value'));
@@ -99,13 +103,13 @@ class ArrayValueTest extends TestCase
 
         $set = ArrayValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ArrayValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertIsArray($dummy->getValue());
         static::assertSame([], $dummy->getValue());
         static::assertSame([], $get('value'));

--- a/tests/Hydrator/Property/ObjectValueTest.php
+++ b/tests/Hydrator/Property/ObjectValueTest.php
@@ -1,10 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Property;
 
+use Closure;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Statistic\MailClientStatisticItemConfig;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\Statistic\MailClientStatisticItemInterface;
+use stdClass;
 
 /**
  * Class ObjectValueTest
@@ -15,7 +19,7 @@ class ObjectValueTest extends TestCase
 {
     public function testEverything()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->item = [
             'some thing' => 'fine'
         ];
@@ -36,20 +40,20 @@ class ObjectValueTest extends TestCase
 
         $set = ObjectValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertNull($dummy->getValue());
         static::assertNull($get('value'));
     }
 
     public function testContainsHydratedObjects()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->description = 'some thing';
         $testValue->count = 456;
 
@@ -69,19 +73,19 @@ class ObjectValueTest extends TestCase
 
         $set = ObjectValue::set('value', new MailClientStatisticItemConfig());
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertInstanceOf(MailClientStatisticItemInterface::class, $dummy->getValue());
     }
 
     public function testEverythingIfItemNotArray()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->item = 'fine';
 
         $dummy = new class {
@@ -100,13 +104,13 @@ class ObjectValueTest extends TestCase
 
         $set = ObjectValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertNull($dummy->getValue());
         static::assertNull($get('value'));
     }
@@ -131,20 +135,20 @@ class ObjectValueTest extends TestCase
 
         $set = ObjectValue::set('value');
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertNull($dummy->getValue());
         static::assertNull($get('value'));
     }
 
     public function testContainsHydratedObjectsIfValueIsArray()
     {
-        $testValue = new \stdClass();
+        $testValue = new stdClass();
         $testValue->description = 'some thing';
         $testValue->count = 456;
 
@@ -164,13 +168,13 @@ class ObjectValueTest extends TestCase
 
         $set = ObjectValue::set('value', new MailClientStatisticItemConfig());
         $set = $set->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $set);
+        static::assertInstanceOf(Closure::class, $set);
 
         $set($testValue, 'value', $dummy);
 
         $get = ObjectValue::get('value');
         $get = $get->bindTo($dummy, $dummy);
-        static::assertInstanceOf(\Closure::class, $get);
+        static::assertInstanceOf(Closure::class, $get);
         static::assertInstanceOf(MailClientStatisticItemInterface::class, $dummy->getValue());
     }
 }

--- a/tests/Mapper/ResponseMapperTest.php
+++ b/tests/Mapper/ResponseMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector\Mapper;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -8,6 +10,7 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
 use Scn\EvalancheSoapApiConnector\TestCase;
 use Scn\EvalancheSoapStruct\Struct\User\UserInterface;
 use Scn\Hydrator\HydratorInterface;
+use stdClass;
 
 class ResponseMapperTest extends TestCase
 {
@@ -32,7 +35,7 @@ class ResponseMapperTest extends TestCase
     public function testGetIntegerCanReturnInteger()
     {
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = 5;
 
         $this->assertSame(5, $this->subject->getInteger($response, $responseProperty));
@@ -41,13 +44,13 @@ class ResponseMapperTest extends TestCase
     public function testGetIntegerCanThrowException()
     {
         $this->expectException(EmptyResultException::class);
-        $this->subject->getInteger(new \stdClass(), 'something');
+        $this->subject->getInteger(new stdClass(), 'something');
     }
 
     public function testGetBooleanCanReturnBool()
     {
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = true;
 
         $this->assertTrue($this->subject->getBoolean($response, $responseProperty));
@@ -56,13 +59,13 @@ class ResponseMapperTest extends TestCase
     public function testGetBooleanCanThrowException()
     {
         $this->expectException(EmptyResultException::class);
-        $this->subject->getBoolean(new \stdClass(), 'something');
+        $this->subject->getBoolean(new stdClass(), 'something');
     }
 
     public function testGetStringCanReturnString()
     {
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = 'some string';
 
         $this->assertSame('some string', $this->subject->getString($response, $responseProperty));
@@ -71,13 +74,13 @@ class ResponseMapperTest extends TestCase
     public function testGetStringCanThrowException()
     {
         $this->expectException(EmptyResultException::class);
-        $this->subject->getString(new \stdClass(), 'something');
+        $this->subject->getString(new stdClass(), 'something');
     }
 
     public function testGetArrayCanReturnArray()
     {
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = [
             'soem' => 'array',
             'key' => 'value',
@@ -89,17 +92,17 @@ class ResponseMapperTest extends TestCase
     public function testGetArrayCanThrowException()
     {
         $this->expectException(EmptyResultException::class);
-        $this->subject->getArray(new \stdClass(), 'something');
+        $this->subject->getArray(new stdClass(), 'something');
     }
 
     public function testGetObjectCanReturnObject()
     {
-        $responseObject = new \stdClass();
+        $responseObject = new stdClass();
         $responseObject->id = 1;
         $responseObject->demo = 55;
 
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = $responseObject;
 
         $someUser = $this->getMockBuilder(UserInterface::class)->getMock();
@@ -125,7 +128,7 @@ class ResponseMapperTest extends TestCase
     {
         $this->expectException(EmptyResultException::class);
         $this->subject->getObject(
-            new \stdClass(),
+            new stdClass(),
             'something',
             $this->getMockBuilder(HydratorConfigInterface::class)->getMock()
         );
@@ -133,22 +136,22 @@ class ResponseMapperTest extends TestCase
 
     public function testGetObjectsCanReturnObjects()
     {
-        $firstResponseObject = new \stdClass();
+        $firstResponseObject = new stdClass();
         $firstResponseObject->id = 1;
         $firstResponseObject->demo = 55;
 
-        $secondResponseObject = new \stdClass();
+        $secondResponseObject = new stdClass();
         $secondResponseObject->id = 1;
         $secondResponseObject->demo = 55;
 
-        $collection = new \stdClass();
+        $collection = new stdClass();
         $collection->item = [
             $firstResponseObject,
             $secondResponseObject
         ];
 
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = $collection;
 
         $someUser = $this->getMockBuilder(UserInterface::class)->getMock();
@@ -175,22 +178,22 @@ class ResponseMapperTest extends TestCase
 
     public function testGetObjectsCanReturnEmptyArray()
     {
-        $firstResponseObject = new \stdClass();
+        $firstResponseObject = new stdClass();
         $firstResponseObject->id = 1;
         $firstResponseObject->demo = 55;
 
-        $secondResponseObject = new \stdClass();
+        $secondResponseObject = new stdClass();
         $secondResponseObject->id = 1;
         $secondResponseObject->demo = 55;
 
-        $collection = new \stdClass();
+        $collection = new stdClass();
         $collection->items = [
             $firstResponseObject,
             $secondResponseObject
         ];
 
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = $collection;
 
         $hydratorConfig = $this->getMockBuilder(HydratorConfigInterface::class)->getMock();
@@ -207,19 +210,19 @@ class ResponseMapperTest extends TestCase
 
     public function testGetObjectsCanReturnSingleObject()
     {
-        $firstResponseObject = new \stdClass();
+        $firstResponseObject = new stdClass();
         $firstResponseObject->id = 1;
         $firstResponseObject->demo = 55;
 
-        $secondResponseObject = new \stdClass();
+        $secondResponseObject = new stdClass();
         $secondResponseObject->id = 1;
         $secondResponseObject->demo = 55;
 
-        $collection = new \stdClass();
+        $collection = new stdClass();
         $collection->item = $firstResponseObject;
 
         $responseProperty = 'someThing';
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->$responseProperty = $collection;
 
         $someUser = $this->getMockBuilder(UserInterface::class)->getMock();
@@ -245,7 +248,7 @@ class ResponseMapperTest extends TestCase
     {
         $this->expectException(EmptyResultException::class);
         $this->subject->getObjects(
-            new \stdClass(),
+            new stdClass(),
             'something',
             $this->getMockBuilder(HydratorConfigInterface::class)->getMock()
         );
@@ -253,7 +256,7 @@ class ResponseMapperTest extends TestCase
 
     public function testGetObjectDirectlyCanReturnObject()
     {
-        $responseObject = new \stdClass();
+        $responseObject = new stdClass();
         $responseObject->id = 1;
         $responseObject->demo = 55;
 
@@ -279,15 +282,15 @@ class ResponseMapperTest extends TestCase
 
     public function testGetObjectsDirectyCanReturnArrayOfObjects()
     {
-        $firstResponseObject = new \stdClass();
+        $firstResponseObject = new stdClass();
         $firstResponseObject->id = 1;
         $firstResponseObject->demo = 55;
 
-        $secondResponseObject = new \stdClass();
+        $secondResponseObject = new stdClass();
         $secondResponseObject->id = 1;
         $secondResponseObject->demo = 55;
 
-        $response = new \stdClass();
+        $response = new stdClass();
         $response->item = [
             $firstResponseObject,
             $secondResponseObject

--- a/tests/SoapClientFactoryTest.php
+++ b/tests/SoapClientFactoryTest.php
@@ -1,6 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector;
+
+use SoapClient;
+use SoapFault;
 
 /**
  * Class SoapClientFactoryTest
@@ -26,7 +31,7 @@ class SoapClientFactoryTest extends TestCase
         $config = $this->getMockBuilder(EvalancheConfigInterface::class)->getMock();
         $config->expects($this->once())->method('getWsdlServiceUrl')->with($portname)->willReturn('something wrong');
 
-        $this->expectException(\SoapFault::class);
+        $this->expectException(SoapFault::class);
         $this->subject->create($config, $portname);
     }
 
@@ -40,7 +45,7 @@ class SoapClientFactoryTest extends TestCase
 
 
         $this->assertInstanceOf(
-            \SoapClient::class,
+            SoapClient::class,
             $this->subject->create($config, $portname)
         );
     }
@@ -55,7 +60,7 @@ class SoapClientFactoryTest extends TestCase
         $config->expects($this->once())->method('getWsdlServiceUrl')->with($portname)->willReturn(__DIR__ . '/' . $portname);
 
         $this->assertInstanceOf(
-            \SoapClient::class,
+            SoapClient::class,
             $this->subject->create($config, $portname)
         );
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Scn\EvalancheSoapApiConnector;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionException;
 
 /**
  * Class TestCase
@@ -13,8 +18,8 @@ class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * @param array $wsdl_methods
      *
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     * @throws \ReflectionException
+     * @return MockObject
+     * @throws ReflectionException
      */
     public function getWsdlMock(array $wsdl_methods = [])
     {


### PR DESCRIPTION
- Remove some unnused imports, remove some fqdn qualifiers and enable
  strict mode for tests.
- Update php requirement for dev to 7.3.; update phpunit

Fixes #123