### PR TITLE
Update ContainerType documentation

### DIFF
--- a/docs/containertype.md
+++ b/docs/containertype.md
@@ -95,7 +95,7 @@ Remove an attribute group of a container type
 
 
 ```
-removeAttribute(
+removeAttributeGroup(
     int <container-type-id>
     int <attribute-group-id>
 ): bool


### PR DESCRIPTION
Fixes wrong method to remove a ContainerType group.