### PR TITLE
Remove function declaration from profile.md

### DIFF
--- a/docs/profile.md
+++ b/docs/profile.md
@@ -78,7 +78,7 @@ Retrieve all profiles of a milestone in a certain date
 
 
 ```
-public function getByMilestone(
+getByMilestone(
 	int <milestone-id>,
 	string[] <pool-attribute-names>,
 	int <timestamp-start>,


### PR DESCRIPTION
There seems to be a parsing error where the `public function` declaration got passed to the documentation content.