### PR TITLE
Fixes profileData is always empty for getBounces()

### DIFF
--- a/src/Hydrator/Config/Profile/ProfileBounceStatusConfig.php
+++ b/src/Hydrator/Config/Profile/ProfileBounceStatusConfig.php
@@ -3,6 +3,7 @@
 namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Profile;
 
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
+use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\HashMapConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Property;
 use Scn\EvalancheSoapStruct\Struct\Profile\ProfileBounceStatus;
 use Scn\EvalancheSoapStruct\Struct\StructInterface;

--- a/src/Hydrator/Config/Profile/ProfileBounceStatusConfig.php
+++ b/src/Hydrator/Config/Profile/ProfileBounceStatusConfig.php
@@ -34,7 +34,7 @@ class ProfileBounceStatusConfig implements HydratorConfigInterface
             'mailing_id' => IntegerValue::set('mailingId'),
             'status' => IntegerValue::set('status'),
             'timestamp' => IntegerValue::set('timestamp'),
-            'profile_data' => Property\ArrayValue::set('profileData'),
+            'profile_data' => Property\ObjectValue::set('profileData', new HashMapConfig()),
         ];
     }
 
@@ -48,7 +48,7 @@ class ProfileBounceStatusConfig implements HydratorConfigInterface
             'mailing_id' => IntegerValue::get('mailingId'),
             'status' => IntegerValue::get('status'),
             'timestamp' => IntegerValue::get('timestamp'),
-            'profile_data' => Property\ArrayValue::get('profileData'),
+            'profile_data' => Property\ObjectValue::get('profileData'),
         ];
     }
 }


### PR DESCRIPTION
When doing a $profile->getBounces() it always returns empty as the Hydrator has a wrong config.