### PR TITLE
Allow users to set some soap client config settings #147

### DIFF
--- a/src/Client/Container/ContainerClient.php
+++ b/src/Client/Container/ContainerClient.php
@@ -4,7 +4,6 @@ namespace Scn\EvalancheSoapApiConnector\Client\Container;
 
 use Scn\EvalancheSoapApiConnector\Client\AbstractClient;
 use Scn\EvalancheSoapApiConnector\Client\ClientInterface;
-use Scn\EvalancheSoapApiConnector\Client\Generic\CreateResourceTrait;
 use Scn\EvalancheSoapApiConnector\Client\Generic\ResourceTrait;
 use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
 use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;

--- a/src/Client/Container/ContainerClientInterface.php
+++ b/src/Client/Container/ContainerClientInterface.php
@@ -3,7 +3,6 @@
 namespace Scn\EvalancheSoapApiConnector\Client\Container;
 
 use Scn\EvalancheSoapApiConnector\Client\ClientInterface;
-use Scn\EvalancheSoapApiConnector\Client\Generic\CreateResourceTraitInterface;
 use Scn\EvalancheSoapApiConnector\Client\Generic\ResourceTraitInterface;
 use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
 use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;

--- a/src/EvalancheConfig.php
+++ b/src/EvalancheConfig.php
@@ -30,21 +30,29 @@ class EvalancheConfig implements EvalancheConfigInterface
     private $debugMode;
 
     /**
+     * @var array<string, mixed>
+     */
+    private $soapClientOptions;
+
+    /**
      * @param string $hostname
      * @param string $username
      * @param string $password
      * @param bool $debugMode
+     * @param array<string, mixed> $soapClientOptions
      */
     public function __construct(
         string $hostname,
         string $username,
         string $password,
-        bool $debugMode = false
+        bool $debugMode = false,
+        array $soapClientOptions = []
     ) {
         $this->hostname = $hostname;
         $this->username = $username;
         $this->password = $password;
         $this->debugMode = $debugMode;
+        $this->soapClientOptions = $soapClientOptions;
     }
 
     /**
@@ -82,6 +90,14 @@ class EvalancheConfig implements EvalancheConfigInterface
     public function getDebugMode(): bool
     {
         return $this->debugMode;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSoapClientOptions(): array
+    {
+        return $this->soapClientOptions;
     }
 
     /**

--- a/src/EvalancheConfigInterface.php
+++ b/src/EvalancheConfigInterface.php
@@ -33,4 +33,9 @@ interface EvalancheConfigInterface
      * @return bool
      */
     public function getDebugMode(): bool;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getSoapClientOptions(): array;
 }

--- a/src/EvalancheConnection.php
+++ b/src/EvalancheConnection.php
@@ -37,14 +37,20 @@ final class EvalancheConnection implements EvalancheConnectionInterface
         $this->extractor = $extractor;
     }
 
-    public static function create(string $hostname, string $username, string $password, $debugMode = false): EvalancheConnectionInterface
-    {
+    public static function create(
+        string $hostname,
+        string $username,
+        string $password,
+        bool $debugMode = false,
+        array $soapClientOptions = []
+    ): EvalancheConnectionInterface {
         return new EvalancheConnection(
             new EvalancheConfig(
                 $hostname,
                 $username,
                 $password,
-                $debugMode
+                $debugMode,
+                $soapClientOptions
             ),
             new SoapClientFactory(),
             new ResponseMapper(

--- a/src/SoapClientFactory.php
+++ b/src/SoapClientFactory.php
@@ -10,54 +10,65 @@ namespace Scn\EvalancheSoapApiConnector;
 final class SoapClientFactory implements SoapClientFactoryInterface
 {
     /**
+     * Merges soap settings and creates a new evalanche soap client instance
+     * Order of soap settings:
+     * - default
+     * - user-defined
+     * - debug
+     * - pre-defined
+     *
      * @param EvalancheConfigInterface $config
      * @param string $wsdlUri
      *
      * @return EvalancheSoapClient
      */
-    public function create(EvalancheConfigInterface $config, string $wsdlUri): EvalancheSoapClient
-    {
-        $soapSettings = [
-            'login' => $config->getUsername(),
-            'password' => $config->getPassword(),
-            'style' => SOAP_DOCUMENT,
-            'use' => SOAP_LITERAL,
-            'soap_version' => SOAP_1_1,
-            'cache_wsdl' => WSDL_CACHE_NONE,
-        ];
-
-        $debug = $config->getDebugMode();
-
-        if ($debug === true) {
-            $soapSettings = array_merge($soapSettings, $this->getDebugSettings());
-        }
-
-        $soapClient = new EvalancheSoapClient(
-            $config->getWsdlServiceUrl($wsdlUri),
-            $soapSettings,
-            $debug
+    public function create(
+        EvalancheConfigInterface $config,
+        string $wsdlUri
+    ): EvalancheSoapClient {
+        $soapSettings = array_merge(
+            [
+                'cache_wsdl' => WSDL_CACHE_NONE,
+            ],
+            $config->getSoapClientOptions(),
+            $this->getDebugSettings($config),
+            [
+                'login' => $config->getUsername(),
+                'password' => $config->getPassword(),
+                'style' => SOAP_DOCUMENT,
+                'use' => SOAP_LITERAL,
+                'soap_version' => SOAP_1_1,
+            ]
         );
 
-        return $soapClient;
+        return new EvalancheSoapClient(
+            $config->getWsdlServiceUrl($wsdlUri),
+            $soapSettings,
+            $config->getDebugMode()
+        );
     }
 
     /**
+     * @param EvalancheConfigInterface $config
      *
-     * @return array
+     * @return array<string, mixed>
      */
-    private function getDebugSettings(): array
-    {
-        $context = stream_context_create([
-            'ssl' => [
-                'verify_peer' => false,
-                'verify_peer_name' => false,
-                'allow_self_signed' => true
-            ]
-        ]);
+    private function getDebugSettings(
+        EvalancheConfigInterface $config
+    ): array {
+        if ($config->getDebugMode() === false) {
+            return [];
+        }
 
         return [
             'trace' => true,
-            'stream_context' => $context
+            'stream_context' => stream_context_create([
+                'ssl' => [
+                    'verify_peer' => false,
+                    'verify_peer_name' => false,
+                    'allow_self_signed' => true
+                ]
+            ])
         ];
     }
 }

--- a/src/SoapClientFactoryInterface.php
+++ b/src/SoapClientFactoryInterface.php
@@ -15,5 +15,8 @@ interface SoapClientFactoryInterface
      *
      * @return EvalancheSoapClient
      */
-    public function create(EvalancheConfigInterface $config, string $wsdlUri): EvalancheSoapClient;
+    public function create(
+        EvalancheConfigInterface $config,
+        string $wsdlUri
+    ): EvalancheSoapClient;
 }

--- a/tests/EvalancheConfigTest.php
+++ b/tests/EvalancheConfigTest.php
@@ -11,10 +11,11 @@ namespace Scn\EvalancheSoapApiConnector;
  */
 class EvalancheConfigTest extends TestCase
 {
-    /**
-     * @var EvalancheConfig
-     */
+    /** @var EvalancheConfig */
     private $subject;
+
+    /** @var array<string, mixed> */
+    private $soapSettings = ['some' => 'setting'];
 
     public function setUp(): void
     {
@@ -22,7 +23,8 @@ class EvalancheConfigTest extends TestCase
             'some hostname',
             'some username',
             'some password',
-            true
+            true,
+            $this->soapSettings
         );
     }
 
@@ -49,5 +51,13 @@ class EvalancheConfigTest extends TestCase
     public function testGetDebugModeCanReturnBoolean()
     {
         $this->assertTrue($this->subject->getDebugMode());
+    }
+
+    public function testGetSoapSettingsReturnsData(): void
+    {
+        $this->assertSame(
+            $this->soapSettings,
+            $this->subject->getSoapClientOptions()
+        );
     }
 }

--- a/tests/SoapClientFactoryTest.php
+++ b/tests/SoapClientFactoryTest.php
@@ -54,7 +54,7 @@ class SoapClientFactoryTest extends TestCase
     {
         $portname = 'evalanche.wsdl';
         $config = $this->getMockBuilder(EvalancheConfigInterface::class)->getMock();
-        $config->expects($this->once())->method('getDebugMode')->willReturn(true);
+        $config->expects($this->exactly(2))->method('getDebugMode')->willReturn(true);
         $config->expects($this->once())->method('getUsername')->willReturn('some username');
         $config->expects($this->once())->method('getPassword')->willReturn('some password');
         $config->expects($this->once())->method('getWsdlServiceUrl')->with($portname)->willReturn(__DIR__ . '/' . $portname);


### PR DESCRIPTION
Users may need to set some custom soap client settings, like
`keep_alive` or proxy configuration. Therefor we allow to apply some
custom settings without overwriting our sane default ones.