### PR TITLE
Fix deprecated warning for PHP 8.1

### DIFF
--- a/src/EvalancheSoapClient.php
+++ b/src/EvalancheSoapClient.php
@@ -61,7 +61,7 @@ class EvalancheSoapClient extends SoapClient
      * @throws RequestException
      */
     #[\ReturnTypeWillChange]
-    public function __call($name, $args = [])
+    public function __call($name, $args = []): mixed
     {
         try {
             return $this->__soapCall($name, $args);


### PR DESCRIPTION
In order to match the SoapClient implementation for `__call()` the return type should be `mixed` for PHP 8.1 *(not tested for PHP 8.0)*. ([Link to documentation](https://www.php.net/manual/de/soapclient.call.php))

Warning:
```sh
Deprecated: Return type of Scn\EvalancheSoapApiConnector\EvalancheSoapClient::__call($name, $args = []) should either be compatible with SoapClient::__call(string $name, array $args): mixed.
```