### PR TITLE
Add ArticleType Client getAttributes method to interface

### DIFF
--- a/src/Client/Article/ArticleTypeClientInterface.php
+++ b/src/Client/Article/ArticleTypeClientInterface.php
@@ -111,6 +111,14 @@ interface ArticleTypeClientInterface extends ClientInterface, ResourceTraitInter
 
     /**
      * @param int $id
+     *
+     * @return ContainerAttributeInterface[]
+     * @throws EmptyResultException
+     */
+    public function getAttributes(int $id): array;
+
+    /**
+     * @param int $id
      * @param int $attributeId
      *
      * @return bool


### PR DESCRIPTION
Noticed while doing some refactoring on our side, that the ArticleTypeClient doesn't have getAttributes method in the interface.

When using the Connection create method, it returns the Interface and I wondered where this method went, because we used it before.

My current "workaround"
```
            $articleTypeClient = $connection->createArticleTypeClient();
            assert($articleTypeClient instanceof ArticleTypeClient);
            $this->articleTypeClient = $articleTypeClient;
```
