### PR TITLE
Support new content-generation api methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require": {
     "php": "^8.1",
     "ext-soap": "*",
-    "scn/evalanche-soap-api-struct": "^2.4",
+    "scn/evalanche-soap-api-struct": "^2.5",
     "scn/hydrator": "^2|^3",
     "scn/hydrator-property-values": "^2.0|^3.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57f715ac57c3b9e8935db1cbe8e77334",
+    "content-hash": "5dbef3ef40eb1099ff396b134f619841",
     "packages": [
         {
             "name": "scn/evalanche-soap-api-struct",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SC-Networks/evalanche-soap-api-struct.git",
-                "reference": "de362d255adb88730ca7be22a97d4bf5a8a84f7b"
+                "reference": "1ae911cfe7868a9eac51484f841debba86b4fcbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SC-Networks/evalanche-soap-api-struct/zipball/de362d255adb88730ca7be22a97d4bf5a8a84f7b",
-                "reference": "de362d255adb88730ca7be22a97d4bf5a8a84f7b",
+                "url": "https://api.github.com/repos/SC-Networks/evalanche-soap-api-struct/zipball/1ae911cfe7868a9eac51484f841debba86b4fcbf",
+                "reference": "1ae911cfe7868a9eac51484f841debba86b4fcbf",
                 "shasum": ""
             },
             "require": {
@@ -61,9 +61,9 @@
             ],
             "support": {
                 "issues": "https://github.com/SC-Networks/evalanche-soap-api-struct/issues",
-                "source": "https://github.com/SC-Networks/evalanche-soap-api-struct/tree/2.4.0"
+                "source": "https://github.com/SC-Networks/evalanche-soap-api-struct/tree/2.5.0"
             },
-            "time": "2025-01-09T08:39:41+00:00"
+            "time": "2025-09-17T08:10:08+00:00"
         },
         {
             "name": "scn/hydrator",
@@ -554,16 +554,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.86.0",
+            "version": "v3.87.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "4a952bd19dc97879b0620f495552ef09b55f7d36"
+                "reference": "da5f0a7858c79b56fc0b8c36d3efcfe5f37f0992"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/4a952bd19dc97879b0620f495552ef09b55f7d36",
-                "reference": "4a952bd19dc97879b0620f495552ef09b55f7d36",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/da5f0a7858c79b56fc0b8c36d3efcfe5f37f0992",
+                "reference": "da5f0a7858c79b56fc0b8c36d3efcfe5f37f0992",
                 "shasum": ""
             },
             "require": {
@@ -574,39 +574,38 @@
                 "ext-hash": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "fidry/cpu-core-counter": "^1.2",
+                "fidry/cpu-core-counter": "^1.3",
                 "php": "^7.4 || ^8.0",
                 "react/child-process": "^0.6.6",
                 "react/event-loop": "^1.5",
-                "react/promise": "^3.2",
+                "react/promise": "^3.3",
                 "react/socket": "^1.16",
                 "react/stream": "^1.4",
                 "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0",
-                "symfony/console": "^5.4.47 || ^6.4.13 || ^7.0",
-                "symfony/event-dispatcher": "^5.4.45 || ^6.4.13 || ^7.0",
-                "symfony/filesystem": "^5.4.45 || ^6.4.13 || ^7.0",
-                "symfony/finder": "^5.4.45 || ^6.4.17 || ^7.0",
-                "symfony/options-resolver": "^5.4.45 || ^6.4.16 || ^7.0",
-                "symfony/polyfill-mbstring": "^1.32",
-                "symfony/polyfill-php80": "^1.32",
-                "symfony/polyfill-php81": "^1.32",
-                "symfony/process": "^5.4.47 || ^6.4.20 || ^7.2",
-                "symfony/stopwatch": "^5.4.45 || ^6.4.19 || ^7.0"
+                "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0",
+                "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0",
+                "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0",
+                "symfony/polyfill-mbstring": "^1.33",
+                "symfony/polyfill-php80": "^1.33",
+                "symfony/polyfill-php81": "^1.33",
+                "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2",
+                "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.6",
+                "facile-it/paraunit": "^1.3.1 || ^2.7",
                 "infection/infection": "^0.29.14",
-                "justinrainbow/json-schema": "^5.3 || ^6.4",
+                "justinrainbow/json-schema": "^6.5",
                 "keradus/cli-executor": "^2.2",
                 "mikey179/vfsstream": "^1.6.12",
                 "php-coveralls/php-coveralls": "^2.8",
-                "php-cs-fixer/accessible-object": "^1.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
-                "phpunit/phpunit": "^9.6.23 || ^10.5.47 || ^11.5.25",
-                "symfony/polyfill-php84": "^1.32",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.23 || ^7.3.1",
-                "symfony/yaml": "^5.4.45 || ^6.4.23 || ^7.3.1"
+                "phpunit/phpunit": "^9.6.25 || ^10.5.53 || ^11.5.34",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.24 || ^7.3.2",
+                "symfony/yaml": "^5.4.45 || ^6.4.24 || ^7.3.2"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -647,7 +646,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.86.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.87.2"
             },
             "funding": [
                 {
@@ -655,7 +654,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-13T22:36:21+00:00"
+            "time": "2025-09-10T09:51:40+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -895,16 +894,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.22",
+            "version": "2.1.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
+                "reference": "b13345001a8553ec405b7741be0c6b8d7f8b5bf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b13345001a8553ec405b7741be0c6b8d7f8b5bf5",
+                "reference": "b13345001a8553ec405b7741be0c6b8d7f8b5bf5",
                 "shasum": ""
             },
             "require": {
@@ -949,7 +948,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-04T19:17:37+00:00"
+            "time": "2025-09-16T11:33:46+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
@@ -1322,16 +1321,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.53",
+            "version": "10.5.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "32768472ebfb6969e6c7399f1c7b09009723f653"
+                "reference": "4b2d546b336876bd9562f24641b08a25335b06b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/32768472ebfb6969e6c7399f1c7b09009723f653",
-                "reference": "32768472ebfb6969e6c7399f1c7b09009723f653",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b2d546b336876bd9562f24641b08a25335b06b6",
+                "reference": "4b2d546b336876bd9562f24641b08a25335b06b6",
                 "shasum": ""
             },
             "require": {
@@ -1352,7 +1351,7 @@
                 "phpunit/php-timer": "^6.0.0",
                 "sebastian/cli-parser": "^2.0.1",
                 "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.3",
+                "sebastian/comparator": "^5.0.4",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
                 "sebastian/exporter": "^5.1.2",
@@ -1403,7 +1402,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.53"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.55"
             },
             "funding": [
                 {
@@ -1427,7 +1426,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T14:40:06+00:00"
+            "time": "2025-09-14T06:19:20+00:00"
         },
         {
             "name": "psr/container",
@@ -2278,16 +2277,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.3",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
                 "shasum": ""
             },
             "require": {
@@ -2343,15 +2342,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-10-18T14:56:07+00:00"
+            "time": "2025-09-07T05:25:07+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3039,16 +3050,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1"
+                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5f360ebc65c55265a74d23d7fe27f957870158a1",
-                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
+                "reference": "cb0102a1c5ac3807cf3fdf8bea96007df7fdbea7",
                 "shasum": ""
             },
             "require": {
@@ -3113,7 +3124,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.2"
+                "source": "https://github.com/symfony/console/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3133,7 +3144,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-30T17:13:41+00:00"
+            "time": "2025-08-25T06:35:40+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3204,16 +3215,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.3.0",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d"
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/497f73ac996a598c92409b44ac43b6690c4f666d",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/b7dc69e71de420ac04bc9ab830cf3ffebba48191",
+                "reference": "b7dc69e71de420ac04bc9ab830cf3ffebba48191",
                 "shasum": ""
             },
             "require": {
@@ -3264,7 +3275,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3276,11 +3287,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-22T09:11:45+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -3498,16 +3513,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "119bcf13e67dbd188e5dbc74228b1686f66acd37"
+                "reference": "0ff2f5c3df08a395232bbc3c2eb7e84912df911d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/119bcf13e67dbd188e5dbc74228b1686f66acd37",
-                "reference": "119bcf13e67dbd188e5dbc74228b1686f66acd37",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/0ff2f5c3df08a395232bbc3c2eb7e84912df911d",
+                "reference": "0ff2f5c3df08a395232bbc3c2eb7e84912df911d",
                 "shasum": ""
             },
             "require": {
@@ -3545,7 +3560,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.3.2"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -3565,7 +3580,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:36:08+00:00"
+            "time": "2025-08-05T10:16:07+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4068,16 +4083,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.3.0",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af"
+                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
-                "reference": "40c295f2deb408d5e9d2d32b8ba1dd61e36f05af",
+                "url": "https://api.github.com/repos/symfony/process/zipball/32241012d521e2e8a9d713adb0812bb773b907f1",
+                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1",
                 "shasum": ""
             },
             "require": {
@@ -4109,7 +4124,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.3.0"
+                "source": "https://github.com/symfony/process/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -4121,11 +4136,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-17T09:11:12+00:00"
+            "time": "2025-08-18T09:42:54+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4274,16 +4293,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca"
+                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/42f505aff654e62ac7ac2ce21033818297ca89ca",
-                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca",
+                "url": "https://api.github.com/repos/symfony/string/zipball/17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
+                "reference": "17a426cce5fd1f0901fefa9b2a490d0038fd3c9c",
                 "shasum": ""
             },
             "require": {
@@ -4341,7 +4360,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.2"
+                "source": "https://github.com/symfony/string/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -4361,7 +4380,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-10T08:47:49+00:00"
+            "time": "2025-08-25T06:35:40+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Client/Generic/ContentGenerationInterface.php
+++ b/src/Client/Generic/ContentGenerationInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scn\EvalancheSoapApiConnector\Client\Generic;
+
+use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
+use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
+use Scn\EvalancheSoapStruct\Struct\Generic\JobStateInterface;
+
+interface ContentGenerationInterface extends GetJobStateInterface
+{
+    /**
+     * Runs the content-generation
+     *
+     * @throws EmptyResultException
+     */
+    public function runContentGeneration(
+        int $id,
+        HashMapInterface $variables
+    ): JobStateInterface;
+}

--- a/src/Client/Generic/ContentGenerationTrait.php
+++ b/src/Client/Generic/ContentGenerationTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scn\EvalancheSoapApiConnector\Client\Generic;
+
+use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
+use Scn\EvalancheSoapStruct\Struct\Generic\JobStateInterface;
+
+trait ContentGenerationTrait
+{
+    use GetJobStateTrait;
+
+    /** @inheritDoc */
+    public function runContentGeneration(
+        int $id,
+        HashMapInterface $variables
+    ): JobStateInterface {
+        return $this->responseMapper->getObject(
+            $this->soapClient->runContentGeneration([
+                'resource_id' => $id,
+                'variables' => $this->extractor->extract(
+                    $this->hydratorConfigFactory->createHashMapConfig(),
+                    $variables
+                )
+            ]),
+            'runContentGenerationResult',
+            $this->hydratorConfigFactory->createJobStateConfig()
+        );
+    }
+}

--- a/src/Client/Generic/GetJobStateInterface.php
+++ b/src/Client/Generic/GetJobStateInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scn\EvalancheSoapApiConnector\Client\Generic;
+
+use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
+use Scn\EvalancheSoapStruct\Struct\Generic\JobStateInterface;
+
+interface GetJobStateInterface
+{
+    /**
+     * Returns the state of a background-job
+     *
+     * @throws EmptyResultException
+     */
+    public function getJobState(
+        string $job_id,
+    ): JobStateInterface;
+}

--- a/src/Client/Generic/GetJobStateTrait.php
+++ b/src/Client/Generic/GetJobStateTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scn\EvalancheSoapApiConnector\Client\Generic;
+
+use Scn\EvalancheSoapStruct\Struct\Generic\JobStateInterface;
+
+trait GetJobStateTrait
+{
+    /** @inheritDoc */
+    public function getJobState(
+        string $job_id,
+    ): JobStateInterface {
+        return $this->responseMapper->getObject(
+            $this->soapClient->getJobState([
+                'job_id' => $job_id,
+            ]),
+            'getJobStateResult',
+            $this->hydratorConfigFactory->createJobStateConfig()
+        );
+    }
+}

--- a/src/Client/LeadPage/LeadpageClient.php
+++ b/src/Client/LeadPage/LeadpageClient.php
@@ -6,6 +6,7 @@ namespace Scn\EvalancheSoapApiConnector\Client\LeadPage;
 
 use Scn\EvalancheSoapApiConnector\Client\AbstractClient;
 use Scn\EvalancheSoapApiConnector\Client\ClientInterface;
+use Scn\EvalancheSoapApiConnector\Client\Generic\ContentGenerationTrait;
 use Scn\EvalancheSoapApiConnector\Client\Generic\EditorModuleTypesTrait;
 use Scn\EvalancheSoapApiConnector\Client\Generic\ResourceTrait;
 use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
@@ -15,6 +16,7 @@ use Scn\EvalancheSoapStruct\Struct\LeadPage\LeadpageConfigurationInterface;
 
 class LeadpageClient extends AbstractClient implements LeadpageClientInterface
 {
+    use ContentGenerationTrait;
     use ResourceTrait;
     use EditorModuleTypesTrait;
     const PORTNAME = 'leadpage';

--- a/src/Client/LeadPage/LeadpageClientInterface.php
+++ b/src/Client/LeadPage/LeadpageClientInterface.php
@@ -3,6 +3,7 @@
 namespace Scn\EvalancheSoapApiConnector\Client\LeadPage;
 
 use Scn\EvalancheSoapApiConnector\Client\ClientInterface;
+use Scn\EvalancheSoapApiConnector\Client\Generic\ContentGenerationInterface;
 use Scn\EvalancheSoapApiConnector\Client\Generic\EditorModulesTypesTraitInterface;
 use Scn\EvalancheSoapApiConnector\Client\Generic\ResourceTraitInterface;
 use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
@@ -10,7 +11,11 @@ use Scn\EvalancheSoapStruct\Struct\Generic\HashMapInterface;
 use Scn\EvalancheSoapStruct\Struct\Generic\ResourceInformationInterface;
 use Scn\EvalancheSoapStruct\Struct\LeadPage\LeadpageConfigurationInterface;
 
-interface LeadpageClientInterface extends ResourceTraitInterface, EditorModulesTypesTraitInterface, ClientInterface
+interface LeadpageClientInterface extends
+    ContentGenerationInterface,
+    ResourceTraitInterface,
+    EditorModulesTypesTraitInterface,
+    ClientInterface
 {
     /**
      * @param int $id

--- a/src/Client/Mailing/MailingClient.php
+++ b/src/Client/Mailing/MailingClient.php
@@ -4,6 +4,7 @@ namespace Scn\EvalancheSoapApiConnector\Client\Mailing;
 
 use Scn\EvalancheSoapApiConnector\Client\AbstractClient;
 use Scn\EvalancheSoapApiConnector\Client\ClientInterface;
+use Scn\EvalancheSoapApiConnector\Client\Generic\ContentGenerationTrait;
 use Scn\EvalancheSoapApiConnector\Client\Generic\EditorModuleTypesTrait;
 use Scn\EvalancheSoapApiConnector\Client\Generic\ResourceTrait;
 use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
@@ -29,6 +30,7 @@ use Scn\EvalancheSoapStruct\Struct\Statistic\MailingStatisticInterface;
  */
 final class MailingClient extends AbstractClient implements MailingClientInterface
 {
+    use ContentGenerationTrait;
     use ResourceTrait;
     use EditorModuleTypesTrait;
     const PORTNAME = 'mailing';

--- a/src/Client/Mailing/MailingClientInterface.php
+++ b/src/Client/Mailing/MailingClientInterface.php
@@ -3,6 +3,7 @@
 namespace Scn\EvalancheSoapApiConnector\Client\Mailing;
 
 use Scn\EvalancheSoapApiConnector\Client\ClientInterface;
+use Scn\EvalancheSoapApiConnector\Client\Generic\ContentGenerationInterface;
 use Scn\EvalancheSoapApiConnector\Client\Generic\EditorModulesTypesTraitInterface;
 use Scn\EvalancheSoapApiConnector\Client\Generic\ResourceTraitInterface;
 use Scn\EvalancheSoapApiConnector\Exception\EmptyResultException;
@@ -29,7 +30,11 @@ use Scn\EvalancheSoapStruct\Struct\Statistic\MailingStatisticInterface;
  *
  * @package Scn\EvalancheSoapApiConnector\Client\Mailing
  */
-interface MailingClientInterface extends ResourceTraitInterface, EditorModulesTypesTraitInterface, ClientInterface
+interface MailingClientInterface extends
+    ContentGenerationInterface,
+    ResourceTraitInterface,
+    EditorModulesTypesTraitInterface,
+    ClientInterface
 {
     /**
      * @param int $id

--- a/src/Hydrator/Config/Generic/JobStateConfig.php
+++ b/src/Hydrator/Config/Generic/JobStateConfig.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
+use Scn\EvalancheSoapApiConnector\Hydrator\Config\HydratorConfigInterface;
+use Scn\EvalancheSoapStruct\Struct\Generic\JobState;
+use Scn\EvalancheSoapStruct\Struct\StructInterface;
+use Scn\HydratorPropertyValues\Property\IntegerValue;
+use Scn\HydratorPropertyValues\Property\StringValue;
+
+/**
+ * @package Scn\EvalancheSoapApiConnector\Hydrator\Generic
+ */
+class JobStateConfig implements HydratorConfigInterface
+{
+    /**
+     * @return StructInterface
+     */
+    public function getObject(): StructInterface
+    {
+        return new JobState();
+    }
+
+    /**
+     * @return array
+     */
+    public function getHydratorProperties(): array
+    {
+        return [
+            'id' => StringValue::set('id'),
+            'status' => IntegerValue::set('status'),
+            'status_description' => StringValue::set('statusDescription'),
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function getExtractorProperties(): array
+    {
+        return [
+            'id' => StringValue::get('id'),
+            'status' => IntegerValue::get('status'),
+            'status_description' => StringValue::get('statusDescription'),
+        ];
+    }
+}

--- a/src/Hydrator/Config/HydratorConfigFactory.php
+++ b/src/Hydrator/Config/HydratorConfigFactory.php
@@ -18,6 +18,7 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\FolderInformationConfi
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\HashMapConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobHandleConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobResultConfig;
+use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobStateConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\MassUpdateResultConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\ResourceInformationConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\ResourceTypeInformationConfig;
@@ -375,5 +376,10 @@ final class HydratorConfigFactory implements HydratorConfigFactoryInterface
     public function createMailingTemplateAllowedTemplatesConfig(): HydratorConfigInterface
     {
         return new MailingTemplateAllowedTemplatesConfig();
+    }
+
+    public function createJobStateConfig(): HydratorConfigInterface
+    {
+        return new JobStateConfig();
     }
 }

--- a/src/Hydrator/Config/HydratorConfigFactoryInterface.php
+++ b/src/Hydrator/Config/HydratorConfigFactoryInterface.php
@@ -127,4 +127,6 @@ interface HydratorConfigFactoryInterface
     public function createArticleIndividualizationConfig(): HydratorConfigInterface;
 
     public function createMailingTemplateAllowedTemplatesConfig(): HydratorConfigInterface;
+
+    public function createJobStateConfig(): HydratorConfigInterface;
 }

--- a/tests/Hydrator/Config/Generic/JobStateConfigTest.php
+++ b/tests/Hydrator/Config/Generic/JobStateConfigTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic;
+
+use PHPUnit\Framework\TestCase;
+use Scn\EvalancheSoapStruct\Struct\Generic\JobStateInterface;
+
+class JobStateConfigTest extends TestCase
+{
+    private JobStateConfig $subject;
+
+    /** @var list<string> */
+    private array $arrayKeys = [
+        'id',
+        'status',
+        'status_description',
+    ];
+
+    public function setUp(): void
+    {
+        $this->subject = new JobStateConfig();
+    }
+
+    public function testGetObjectCanReturnInstanceOfJobState(): void
+    {
+        self::assertInstanceOf(
+            JobStateInterface::class,
+            $this->subject->getObject()
+        );
+    }
+
+    public function testGetHydratorPropertiesCanReturnArray(): void
+    {
+        foreach ($this->arrayKeys as $arrayKey) {
+            self::assertArrayHasKey($arrayKey, $this->subject->getHydratorProperties());
+        }
+    }
+
+    public function testGetExtractorPropertiesCanReturnArray(): void
+    {
+        foreach ($this->arrayKeys as $arrayKey) {
+            self::assertArrayHasKey($arrayKey, $this->subject->getExtractorProperties());
+        }
+    }
+}

--- a/tests/Hydrator/Config/HydratorConfigFactoryTest.php
+++ b/tests/Hydrator/Config/HydratorConfigFactoryTest.php
@@ -20,6 +20,7 @@ use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\FolderInformationConfi
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\HashMapConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobHandleConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobResultConfig;
+use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\JobStateConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\MassUpdateResultConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\ResourceInformationConfig;
 use Scn\EvalancheSoapApiConnector\Hydrator\Config\Generic\ResourceTypeInformationConfig;
@@ -156,6 +157,7 @@ class HydratorConfigFactoryTest extends TestCase
             ['createLeadpageConfigurationConfig', LeadpageConfigurationConfig::class],
             ['createLeadpageTemplateSourcesConfig', LeadpageTemplateSourcesConfig::class],
             ['createLeadpageTemplateConfigurationConfig', LeadpageTemplateConfigurationConfig::class],
+            ['createJobStateConfig', JobStateConfig::class],
         ];
     }
 }


### PR DESCRIPTION
This adds the following new methods:
- `runContentGeneration` - Allows to trigger content-generation on mailings/leadpages; returns a generic `JobState`
- `getJobState` - Allows to query the api for the state of a certain Job

Also, this updates the dependencies.